### PR TITLE
Update attrs.js 禁止折行

### DIFF
--- a/src/platforms/mp/compiler/codegen/convert/attrs.js
+++ b/src/platforms/mp/compiler/codegen/convert/attrs.js
@@ -9,13 +9,13 @@ function transformDynamicClass (staticClass = '', clsBinding) {
   const result = babel.transform(`!${clsBinding}`, { plugins: [transformObjectToTernaryOperator] })
   // 先实现功能，再优化代码
   // https://github.com/babel/babel/issues/7138
-  const cls = prettier.format(result.code, { semi: false, singleQuote: true }).slice(1).slice(0, -1)
+  const cls = prettier.format(result.code, { semi: false, singleQuote: true, proseWrap: 'never' }).slice(1).slice(0, -1)
   return `${staticClass} {{${cls}}}`
 }
 
 function transformDynamicStyle (staticStyle = '', styleBinding) {
   const result = babel.transform(`!${styleBinding}`, { plugins: [transformObjectToString] })
-  const cls = prettier.format(result.code, { semi: false, singleQuote: true }).slice(2).slice(0, -2)
+  const cls = prettier.format(result.code, { semi: false, singleQuote: true, proseWrap: 'never' }).slice(2).slice(0, -2)
   return `${staticStyle} {{${cls}}}`
 }
 


### PR DESCRIPTION
[pretter 的 API](https://prettier.io/docs/en/api.html)
prettier.format(source [, options])
format is used to format text using Prettier. Options may be provided to override the defaults.

By default, Prettier will wrap markdown text as-is since some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket. In some cases you may want to rely on editor/viewer soft wrapping instead, so this option allows you to opt out with "never".

Valid options:
[options](https://prettier.io/docs/en/options.html)

available in v1.8.2+

By default, Prettier will wrap markdown text as-is since some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket. In some cases you may want to rely on editor/viewer soft wrapping instead, so this option allows you to opt out with "never".

Valid options:

"always" - Wrap prose if it exceeds the print width.
"never" - Do not wrap prose.
"preserve" - Wrap prose as-is. available in v1.9.0+
DEFAULT	CLI OVERRIDE	API OVERRIDE
"preserve"	--prose-wrap <always|never|preserve>	proseWrap: "<always|never|preserve>"


#87 的解决方案