### PR TITLE
feat: support miniprogram native component properties

### DIFF
--- a/src/platforms/mp/runtime/render.js
+++ b/src/platforms/mp/runtime/render.js
@@ -25,6 +25,7 @@ function getVmData (vm) {
   const dataKeys = [].concat(
     Object.keys(vm._data || {}),
     Object.keys(vm._props || {}),
+    Object.keys(vm._mpProps || {}),
     Object.keys(vm._computedWatchers || {})
   )
   return dataKeys.reduce((res, key) => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

让 mpvue 的组件支持[自定义组件](https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/)

支持微信小程序自定义组件的`properties`，使用`mpvue-simple`可以构建出微信小程序原生的组件，从而能在组件 Component 级别（此前只能是页面 Page ）直接被原生微信小程序引用

现在的代码是个简单的 PoC ，这里有个原生小程序代码引用 mpvue 组件的 demo：https://github.com/jkzing/native-component

大佬们可以先看看能不能接受这个 feature