### PR TITLE
[fix] 解决具名slot编译成template丢失原标签的bug.

### DIFF
--- a/packages/mpvue-template-compiler/build.js
+++ b/packages/mpvue-template-compiler/build.js
@@ -4738,11 +4738,9 @@ function convertAst (node, options, util) {
         var isDefault = Array.isArray(n);
         var slotName = isDefault ? 'default' : n.attrsMap.slot;
         var slotId = moduleId + "-" + slotName + "-" + (mpcomid.replace(/\'/g, ''));
-        var node = isDefault ? { tag: 'slot', attrsMap: {}, children: n } : n;
+        var node = { tag: 'template', attrsMap: { name: slotId }, children: isDefault ? n : [n] };
 
-        node.tag = 'template';
-        node.attrsMap.name = slotId;
-        delete node.attrsMap.slot;
+        !isDefault && delete n.attrsMap.slot;
         // 缓存，会集中生成一个 slots 文件
         slots[slotId] = { node: convertAst(node, options, util), name: slotName, slotId: slotId };
         wxmlAst.slots[slotName] = slotId;

--- a/packages/mpvue/index.js
+++ b/packages/mpvue/index.js
@@ -4144,7 +4144,7 @@ Object.defineProperty(Vue$3.prototype, '$ssrContext', {
 });
 
 Vue$3.version = '2.4.1';
-Vue$3.mpvueVersion = '1.0.11';
+Vue$3.mpvueVersion = '1.0.12';
 
 /* globals renderer */
 

--- a/src/platforms/mp/compiler/codegen/convert/index.js
+++ b/src/platforms/mp/compiler/codegen/convert/index.js
@@ -53,11 +53,9 @@ function convertAst (node, options = {}, util) {
         const isDefault = Array.isArray(n)
         const slotName = isDefault ? 'default' : n.attrsMap.slot
         const slotId = `${moduleId}-${slotName}-${mpcomid.replace(/\'/g, '')}`
-        const node = isDefault ? { tag: 'slot', attrsMap: {}, children: n } : n
+        const node = { tag: 'template', attrsMap: { name: slotId }, children: isDefault ? n : [n] }
 
-        node.tag = 'template'
-        node.attrsMap.name = slotId
-        delete node.attrsMap.slot
+        !isDefault && delete n.attrsMap.slot
         // 缓存，会集中生成一个 slots 文件
         slots[slotId] = { node: convertAst(node, options, util), name: slotName, slotId }
         wxmlAst.slots[slotName] = slotId

--- a/test/mp/compiler/index.spec.js
+++ b/test/mp/compiler/index.spec.js
@@ -546,10 +546,43 @@ describe('slot', () => {
     )
   })
 
-  it('slot name', () => {
+  it('组件定义-默认slot和具名slot', () => {
     assertCodegen(
-      `<card class="baz boo"><a slot="header">test</a></card>`,
-      `<import src="/components/card" /><template name="a"><template data="{{...$root[$kk+'0'], $root, $slotdefault:'hashValue-default-0',$slotheader:'hashValue-header-0'}}" is="card"></template></template>`,
+      `<div class="child"><slot>{{text}}</slot><slot name="other">{{otherText}}</slot></div>`,
+      `<template name="a"><view class="_div child"><template name="default">{{text}}</template><template name="other">{{otherText}}</template><template data="{{...$root[$k], $root}}" is="{{$slotdefault || 'default'}}"></template><template data="{{...$root[$k], $root}}" is="{{$slotother || 'other'}}"></template></view></template>`,
+      {
+        name: 'a'
+      }
+    )
+  })
+
+  it('使用默认slot', () => {
+    assertCodegen(
+      `<card class="baz boo"><div>{{test}}</div></card>`,
+      `<import src="/components/card" /><template name="a"><template data="{{...$root[$kk+'0'], $root, $slotdefault:'hashValue-default-0'}}" is="card"></template></template>`,
+      {
+        name: 'a',
+        components: {
+          card: {
+            name: 'card',
+            src: '/components/card'
+          }
+        },
+        moduleId: 'hashValue'
+      },
+      {
+        mpTips: ['template 不支持此属性-> class="baz boo"'],
+        mpErrors: [],
+        /* eslint-disable */
+        slots: {"hashValue-default-0":{"node":{"tag":"template","attrsMap":{"name":"hashValue-default-0"},"children":[{"type":1,"tag":"view","attrsList":[],"attrsMap":{"class":"_div hashValue"},"parent":{"type":1,"tag":"card","attrsList":[],"attrsMap":{"class":"baz boo"},"children":[],"plain":false,"staticClass":"\"baz boo\"","mpcomid":"'0'","attrs":[{"name":"mpcomid","value":"'0'"}],"static":false,"staticRoot":false},"children":[{"type":2,"expression":"_s(test)","text":"{{test}}","staticClass":"hashValue","slots":{},"attrsMap":{"class":"hashValue"}}],"plain":true,"staticRoot":false,"staticClass":"_div hashValue","slots":{}}],"staticClass":"","slots":{}},"name":"default","slotId":"hashValue-default-0","code":"<template name=\"hashValue-default-0\"><view class=\"_div hashValue\">{{test}}</view></template>"}}
+      }
+    )
+  })
+
+  it('使用具名slot', () => {
+    assertCodegen(
+      `<card class="baz boo"><div slot="named">{{test}}</div></card>`,
+      `<import src="/components/card" /><template name="a"><template data="{{...$root[$kk+'0'], $root, $slotdefault:'hashValue-default-0',$slotnamed:'hashValue-named-0'}}" is="card"></template></template>`,
       {
         name: 'a',
         components: {
@@ -564,7 +597,7 @@ describe('slot', () => {
         mpTips: ['template 不支持此属性-> class="baz boo"'],
         mpErrors: [],
         /* eslint-disable */
-        slots: {"hashValue-default-0":{"node":{"tag":"template","attrsMap":{"name":"hashValue-default-0"},"children":[],"staticClass":"","slots":{}},"name":"default","slotId":"hashValue-default-0","code":"<template name=\"hashValue-default-0\"></template>"},"hashValue-header-0":{"node":{"type":1,"tag":"template","attrsList":[],"attrsMap":{"name":"hashValue-header-0"},"parent":{"type":1,"tag":"card","attrsList":[],"attrsMap":{"class":"baz boo"},"children":[],"plain":false,"staticClass":"\"baz boo\"","mpcomid":"'0'","attrs":[{"name":"mpcomid","value":"'0'"}],"static":false,"staticRoot":false},"children":[{"type":3,"text":"test","staticClass":"hashValue","slots":{},"attrsMap":{"class":"hashValue"}}],"plain":false,"slotTarget":"\"header\"","staticRoot":false,"staticClass":"","slots":{}},"name":"header","slotId":"hashValue-header-0","code":"<template name=\"hashValue-header-0\">test</template>"}}
+        slots: {"hashValue-default-0":{"node":{"tag":"template","attrsMap":{"name":"hashValue-default-0"},"children":[],"staticClass":"","slots":{}},"name":"default","slotId":"hashValue-default-0","code":"<template name=\"hashValue-default-0\"></template>"},"hashValue-named-0":{"node":{"tag":"template","attrsMap":{"name":"hashValue-named-0"},"children":[{"type":1,"tag":"view","attrsList":[],"attrsMap":{"class":"_div hashValue"},"parent":{"type":1,"tag":"card","attrsList":[],"attrsMap":{"class":"baz boo"},"children":[],"plain":false,"staticClass":"\"baz boo\"","mpcomid":"'0'","attrs":[{"name":"mpcomid","value":"'0'"}],"static":false,"staticRoot":false},"children":[{"type":2,"expression":"_s(test)","text":"{{test}}","staticClass":"hashValue","slots":{},"attrsMap":{"class":"hashValue"}}],"plain":false,"slotTarget":"\"named\"","staticRoot":false,"staticClass":"_div hashValue","slots":{}}],"staticClass":"","slots":{}},"name":"named","slotId":"hashValue-named-0","code":"<template name=\"hashValue-named-0\"><view class=\"_div hashValue\">{{test}}</view></template>"}}
       }
     )
   })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
bug描述: 如[demo repo](https://github.com/shawtung/mpvue-demo)
index.vue
```html
<child>
  <span slot="other"> {{product.desc}} </span>
</child>
```
child.vue
```html
<div class="child">
  <slot name="other"> 3{{otherText}} </slot>
</div>
```
最终效果是
```html
<view class="_div data-v-47e6fcf2 child"> desc </view>
```
原先的span, 应该被编译成label, 结果被丢弃了.
经修改之后
```html
<view class="_div data-v-47e6fcf2 child">
  <label class="_span data-v-0d53d50b"> desc </label>
</view>
```
且不影响原非具名slot.

搜了一下issues, 没有这个bug相关的. 就不提issue直接pr了.