### PR TITLE
增加支持小程序原生自定义组件双向数据绑定的功能

### DIFF
--- a/packages/mpvue/index.js
+++ b/packages/mpvue/index.js
@@ -4148,7 +4148,7 @@ Object.defineProperty(Vue$3.prototype, '$ssrContext', {
 });
 
 Vue$3.version = '2.4.1';
-Vue$3.mpvueVersion = '1.0.12';
+Vue$3.mpvueVersion = '1.0.13';
 
 /* globals renderer */
 
@@ -5501,6 +5501,7 @@ function getHandle (vnode, eventid, eventTypes) {
 
   var attrs = data.attrs;
   var on = data.on;
+  var model = data.model;
   if (attrs && on && attrs['eventid'] === eventid) {
     eventTypes.forEach(function (et) {
       var h = on[et];
@@ -5511,6 +5512,12 @@ function getHandle (vnode, eventid, eventTypes) {
       }
     });
     return res
+  } else if (attrs && model && attrs['eventid'] === eventid) {
+    model.callback && res.push(function (event) {
+      if (event && event.mp) {
+        model.callback(event.mp.detail);
+      }
+    });
   }
 
   return res

--- a/src/platforms/mp/runtime/events.js
+++ b/src/platforms/mp/runtime/events.js
@@ -43,7 +43,7 @@ function getHandle (vnode, eventid, eventTypes = []) {
     })
   }
 
-  const { attrs, on } = data
+  const { attrs, on, model } = data
   if (attrs && on && attrs['eventid'] === eventid) {
     eventTypes.forEach(et => {
       const h = on[et]
@@ -54,6 +54,12 @@ function getHandle (vnode, eventid, eventTypes = []) {
       }
     })
     return res
+  } else if (attrs && model && attrs['eventid'] === eventid) {
+    model.callback && res.push(function (event) {
+      if (event && event.mp) {
+        model.callback(event.mp.detail)
+      }
+    })
   }
 
   return res


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
支持小程序原生自定义组件的双向数据绑定（v-model）
例如有小程序原生组件
```
<custom-component v-model="bindValue"></custom-component>
```
当小程序组件内部修改bindValue的值后，使用以下事件可将修改后的值传出
```
this.triggerEvent('change', value);
```
以上事件发出后自动将修改后的值赋值给bindValue变量，实现双向数据绑定
