### PR TITLE
在渲染时使用新的diff算法来减少Vue组件更新引起的Page.setData的实际更新量，达到提升页面性能的目的

### DIFF
--- a/packages/mpvue/index.js
+++ b/packages/mpvue/index.js
@@ -5443,7 +5443,7 @@ function diffData (vm, data) {
           // 引用类型
         if (vmDataItemKey === '__keyPath') { return }
         minifyDeepData(rootKey, vmDataItemKey, vmData[vmDataItemKey], data, vm._mpValueSet, vm);
-      } else {
+      } else if(vmData[vmDataItemKey] !== undefined){
           // _data上的值属性只有要更新的时候才赋值
         if (__keyPathOnThis[vmDataItemKey] === true) {
           data[rootKey + '.' + vmDataItemKey] = vmData[vmDataItemKey];
@@ -5456,7 +5456,7 @@ function diffData (vm, data) {
         // 引用类型
         if (vmPropsItemKey === '__keyPath') { return }
         minifyDeepData(rootKey, vmPropsItemKey, vmProps[vmPropsItemKey], data, vm._mpValueSet, vm);
-      } else {
+      } else if(vmProps[vmPropsItemKey] !== undefined){
         data[rootKey + '.' + vmPropsItemKey] = vmProps[vmPropsItemKey];
       }
       // _props上的值属性只有要更新的时候才赋值

--- a/packages/mpvue/index.js
+++ b/packages/mpvue/index.js
@@ -5469,7 +5469,7 @@ function diffData (vm, data) {
       data[rootKey + '.' + mpItemKey] = vmMpProps[mpItemKey];
     });
     Object.keys(vmComputedWatchers).forEach(function (computedItemKey) {
-      data[rootKey + '.' + computedItemKey] = vmComputedWatchers[computedItemKey];
+      data[rootKey + '.' + computedItemKey] = vmComputedWatchers[computedItemKey]['value'];
     });
       // 更新的时候要删除$root.0:{},否则会覆盖原正确数据
     delete data[rootKey];

--- a/packages/mpvue/index.js
+++ b/packages/mpvue/index.js
@@ -763,10 +763,13 @@ var observerState = {
  * object's property keys into getter/setters that
  * collect dependencies and dispatches updates.
  */
-var Observer = function Observer (value) {
+var Observer = function Observer (value, key) {
   this.value = value;
   this.dep = new Dep();
   this.vmCount = 0;
+  if (key) {
+    this.key = key;
+  }
   def(value, '__ob__', this);
   if (Array.isArray(value)) {
     var augment = hasProto
@@ -829,7 +832,7 @@ function copyAugment (target, src, keys) {
  * returns the new observer if successfully observed,
  * or the existing observer if the value already has one.
  */
-function observe (value, asRootData) {
+function observe (value, asRootData, key) {
   if (!isObject(value)) {
     return
   }
@@ -843,7 +846,9 @@ function observe (value, asRootData) {
     Object.isExtensible(value) &&
     !value._isVue
   ) {
-    ob = new Observer(value);
+    ob = new Observer(value, key);
+    ob.__keyPath = ob.__keyPath ? ob.__keyPath : {};
+    ob.__keyPath[key] = true;
   }
   if (asRootData && ob) {
     ob.vmCount++;
@@ -868,11 +873,13 @@ function defineReactive$$1 (
     return
   }
 
+  // TODO: 先试验标记一下 keyPath
+
   // cater for pre-defined getter/setters
   var getter = property && property.get;
   var setter = property && property.set;
 
-  var childOb = !shallow && observe(val);
+  var childOb = !shallow && observe(val, undefined, key);
   Object.defineProperty(obj, key, {
     enumerable: true,
     configurable: true,
@@ -895,6 +902,7 @@ function defineReactive$$1 (
       if (newVal === value || (newVal !== newVal && value !== value)) {
         return
       }
+
       /* eslint-enable no-self-compare */
       if ("production" !== 'production' && customSetter) {
         customSetter();
@@ -904,8 +912,10 @@ function defineReactive$$1 (
       } else {
         val = newVal;
       }
-      childOb = !shallow && observe(newVal);
+      childOb = !shallow && observe(newVal, undefined, key);
       dep.notify();
+      obj.__keyPath = obj.__keyPath ? obj.__keyPath : {};
+      obj.__keyPath[key] = true;
     }
   });
 }
@@ -938,6 +948,9 @@ function set (target, key, val) {
     return val
   }
   defineReactive$$1(ob.value, key, val);
+  // Vue.set 添加对象属性，渲染时候把val传给小程序渲染
+  target.__keyPath = target.__keyPath ? target.__keyPath : {};
+  target.__keyPath[key] = true;
   ob.dep.notify();
   return val
 }
@@ -965,6 +978,9 @@ function del (target, key) {
   if (!ob) {
     return
   }
+  target.__keyPath = target.__keyPath ? target.__keyPath : {};
+  // Vue.del 删除对象属性，渲染时候把这个属性设置为undefined
+  target.__keyPath[key] = 'del';
   ob.dep.notify();
 }
 
@@ -4148,7 +4164,7 @@ Object.defineProperty(Vue$3.prototype, '$ssrContext', {
 });
 
 Vue$3.version = '2.4.1';
-Vue$3.mpvueVersion = '1.0.12';
+Vue$3.mpvueVersion = '1.0.13';
 
 /* globals renderer */
 
@@ -5293,6 +5309,182 @@ function initMP (mpType, next) {
   }
 }
 
+var updateDataTotal = 0; // 总共更新的数据量
+function diffLog (updateData) {
+  updateData = JSON.stringify(updateData);
+  if (!Vue$3._mpvueTraceTimer) {
+    Vue$3._mpvueTraceTimer = setTimeout(function () {
+      clearTimeout(Vue$3._mpvueTraceTimer);
+      updateDataTotal = (updateDataTotal / 1024).toFixed(1);
+      console.log('这次操作引发500ms内数据更新量:' + updateDataTotal + 'kb');
+      Vue$3._mpvueTraceTimer = 0;
+      updateDataTotal = 0;
+    }, 500);
+  } else if (Vue$3._mpvueTraceTimer) {
+    updateData = updateData.replace(/[^\u0000-\u00ff]/g, 'aa'); // 中文占2字节，中文替换成两个字母计算占用空间
+    updateDataTotal += updateData.length;
+  }
+}
+
+function getDeepData (keyList, viewData) {
+  if (keyList.length > 1) {
+    var _key = keyList.splice(0, 1);
+    var _viewData = viewData[_key];
+    if (_viewData) {
+      return getDeepData(keyList, _viewData)
+    } else {
+      return null
+    }
+  } else {
+    if (viewData[keyList[0]]) {
+      return viewData[keyList[0]]
+    } else {
+      return null
+    }
+  }
+}
+function compareAndSetDeepData (key, newData, vm, data) {
+  // 比较引用类型数据
+  try {
+    var keyList = key.split('.');
+     //page.__viewData__老版小程序不存在，使用mpvue里绑的data比对
+    var oldData = getDeepData(keyList, vm.$root.$mp.page.data);
+    if (oldData === null || JSON.stringify(oldData) !== JSON.stringify(newData)) {
+      data[key] = newData;
+    }
+  } catch (e) {
+    console.log(e, key, newData, vm);
+  }
+}
+
+function cleanKeyPath (vm) {
+  if (vm.__mpKeyPath) {
+    Object.keys(vm.__mpKeyPath).forEach(function (_key) {
+      delete vm.__mpKeyPath[_key]['__keyPath'];
+    });
+  }
+}
+
+function minifyDeepData (rootKey, originKey, vmData, data, _mpValueSet, vm) {
+  try {
+    if (vmData instanceof Array) {
+       // 数组
+      compareAndSetDeepData(rootKey + '.' + originKey, vmData, vm, data);
+    } else {
+      // Object
+      var _keyPathOnThis = {}; // 存储这层对象的keyPath
+      if (vmData.__keyPath) {
+        // 有更新列表 ，按照更新列表更新
+        _keyPathOnThis = vmData.__keyPath;
+        Object.keys(vmData).forEach(function (_key) {
+          if (vmData[_key] instanceof Object) {
+            // 引用类型 递归
+            if (_key === '__keyPath') {
+              return
+            }
+            minifyDeepData(rootKey + '.' + originKey, _key, vmData[_key], data, null, vm);
+          } else {
+            // 更新列表中的 加入data
+            if (_keyPathOnThis[_key] === true) {
+              if (originKey) {
+                data[rootKey + '.' + originKey + '.' + _key] = vmData[_key];
+              } else {
+                data[rootKey + '.' + _key] = vmData[_key];
+              }
+            }
+          }
+        });
+         // 根节点可能有父子引用同一个引用类型数据，依赖树都遍历完后清理
+        vm['__mpKeyPath'] = vm['__mpKeyPath'] || {};
+        vm['__mpKeyPath'][vmData.__ob__.dep.id] = vmData;
+      } else {
+        // 没有更新列表
+        compareAndSetDeepData(rootKey + '.' + originKey, vmData, vm, data);
+      }
+    }
+  } catch (e) {
+    console.log(e, rootKey, originKey, vmData, data);
+  }
+}
+
+function getRootKey (vm, rootKey) {
+  if (!vm.$parent.$attrs) {
+    rootKey = '$root.0' + ',' + rootKey;
+    return rootKey
+  } else {
+    rootKey = vm.$parent.$attrs.mpcomid + ',' + rootKey;
+    return getRootKey(vm.$parent, rootKey)
+  }
+}
+
+function diffData (vm, data) {
+  var vmData = vm._data || {};
+  var vmProps = vm._props || {};
+  var rootKey = '';
+  if (!vm.$attrs) {
+    rootKey = '$root.0';
+  } else {
+    rootKey = getRootKey(vm, vm.$attrs.mpcomid);
+  }
+  Vue$3.nextTick(function () {
+    cleanKeyPath(vm);
+  });
+  // console.log(rootKey)
+
+    // 值类型变量不考虑优化，还是直接更新
+  var __keyPathOnThis = vmData.__keyPath || vm.__keyPath || {};
+  delete vm.__keyPath;
+  delete vmData.__keyPath;
+  delete vmProps.__keyPath;
+  if (vm._mpValueSet === 'done') {
+    // 第二次赋值才进行缩减操作
+    Object.keys(vmData).forEach(function (vmDataItemKey) {
+      if (vmData[vmDataItemKey] instanceof Object) {
+          // 引用类型
+        if (vmDataItemKey === '__keyPath') { return }
+        minifyDeepData(rootKey, vmDataItemKey, vmData[vmDataItemKey], data, vm._mpValueSet, vm);
+      } else {
+          // _data上的值属性只有要更新的时候才赋值
+        if (__keyPathOnThis[vmDataItemKey] === true) {
+          data[rootKey + '.' + vmDataItemKey] = vmData[vmDataItemKey];
+        }
+      }
+    });
+
+    Object.keys(vmProps).forEach(function (vmPropsItemKey) {
+      if (vmProps[vmPropsItemKey] instanceof Object) {
+        // 引用类型
+        if (vmPropsItemKey === '__keyPath') { return }
+        minifyDeepData(rootKey, vmPropsItemKey, vmProps[vmPropsItemKey], data, vm._mpValueSet, vm);
+      } else {
+        data[rootKey + '.' + vmPropsItemKey] = vmProps[vmPropsItemKey];
+      }
+      // _props上的值属性只有要更新的时候才赋值
+    });
+
+    // 检查完data和props,最后补上_mpProps & _computedWatchers
+    var vmMpProps = vm._mpProps || {};
+    var vmComputedWatchers = vm._computedWatchers || {};
+    Object.keys(vmMpProps).forEach(function (mpItemKey) {
+      data[rootKey + '.' + mpItemKey] = vmMpProps[mpItemKey];
+    });
+    Object.keys(vmComputedWatchers).forEach(function (computedItemKey) {
+      data[rootKey + '.' + computedItemKey] = vmComputedWatchers[computedItemKey];
+    });
+      // 更新的时候要删除$root.0:{},否则会覆盖原正确数据
+    delete data[rootKey];
+  }
+  if (vm._mpValueSet === undefined) {
+      // 第一次设置数据成功后，标记位置true,再更新到这个节点如果没有keyPath数组认为不需要更新
+    vm._mpValueSet = 'done';
+  }
+  if (Vue$3.config.devtools) {
+    // console.log('更新VM节点', vm)
+    // console.log('实际传到Page.setData数据', data)
+    diffLog(data);
+  }
+}
+
 // 节流方法，性能优化
 // 全局的命名约定，为了节省编译的包大小一律采取形象的缩写，说明如下。
 // $c === $child
@@ -5429,6 +5621,8 @@ function getPage (vm) {
   return page
 }
 
+// 优化js变量动态变化时候引起全量更新
+
 // 优化每次 setData 都传递大量新数据
 function updateDataToMP () {
   var page = getPage(this);
@@ -5437,6 +5631,9 @@ function updateDataToMP () {
   }
 
   var data = formatVmData(this);
+
+  diffData(this, data);
+
   throttleSetData(page.setData.bind(page), data);
 }
 

--- a/packages/mpvue/index.js
+++ b/packages/mpvue/index.js
@@ -5466,10 +5466,10 @@ function diffData (vm, data) {
     var vmMpProps = vm._mpProps || {};
     var vmComputedWatchers = vm._computedWatchers || {};
     Object.keys(vmMpProps).forEach(function (mpItemKey) {
-      data[rootKey + '.' + mpItemKey] = vmMpProps[mpItemKey];
+      data[rootKey + '.' + mpItemKey] = vm[mpItemKey];
     });
     Object.keys(vmComputedWatchers).forEach(function (computedItemKey) {
-      data[rootKey + '.' + computedItemKey] = vmComputedWatchers[computedItemKey]['value'];
+      data[rootKey + '.' + computedItemKey] = vm[computedItemKey];
     });
       // 更新的时候要删除$root.0:{},否则会覆盖原正确数据
     delete data[rootKey];

--- a/src/platforms/mp/runtime/diff-data.js
+++ b/src/platforms/mp/runtime/diff-data.js
@@ -118,7 +118,7 @@ export function diffData (vm, data) {
           // 引用类型
         if (vmDataItemKey === '__keyPath') { return }
         minifyDeepData(rootKey, vmDataItemKey, vmData[vmDataItemKey], data, vm._mpValueSet, vm)
-      } else {
+      } else if(vmData[vmDataItemKey] !== undefined){
           // _data上的值属性只有要更新的时候才赋值
         if (__keyPathOnThis[vmDataItemKey] === true) {
           data[rootKey + '.' + vmDataItemKey] = vmData[vmDataItemKey]
@@ -131,7 +131,7 @@ export function diffData (vm, data) {
         // 引用类型
         if (vmPropsItemKey === '__keyPath') { return }
         minifyDeepData(rootKey, vmPropsItemKey, vmProps[vmPropsItemKey], data, vm._mpValueSet, vm)
-      } else {
+      } else if(vmProps[vmPropsItemKey] !== undefined){
         data[rootKey + '.' + vmPropsItemKey] = vmProps[vmPropsItemKey]
       }
       // _props上的值属性只有要更新的时候才赋值

--- a/src/platforms/mp/runtime/diff-data.js
+++ b/src/platforms/mp/runtime/diff-data.js
@@ -22,7 +22,8 @@ function compareAndSetDeepData (key, newData, vm, data) {
   // 比较引用类型数据
   try {
     const keyList = key.split('.')
-    const oldData = getDeepData(keyList, vm.$root.$mp.page.__viewData__)
+     //page.__viewData__老版小程序不存在，使用mpvue里绑的data比对
+    const oldData = getDeepData(keyList, vm.$root.$mp.page.data)
     if (oldData === null || JSON.stringify(oldData) !== JSON.stringify(newData)) {
       data[key] = newData
     }

--- a/src/platforms/mp/runtime/diff-data.js
+++ b/src/platforms/mp/runtime/diff-data.js
@@ -144,7 +144,7 @@ export function diffData (vm, data) {
       data[rootKey + '.' + mpItemKey] = vmMpProps[mpItemKey]
     })
     Object.keys(vmComputedWatchers).forEach((computedItemKey) => {
-      data[rootKey + '.' + computedItemKey] = vmComputedWatchers[computedItemKey]
+      data[rootKey + '.' + computedItemKey] = vmComputedWatchers[computedItemKey]['value']
     })
       // 更新的时候要删除$root.0:{},否则会覆盖原正确数据
     delete data[rootKey]

--- a/src/platforms/mp/runtime/diff-data.js
+++ b/src/platforms/mp/runtime/diff-data.js
@@ -1,0 +1,160 @@
+import Vue from 'core/index'
+import { diffLog } from './runtime-trace'
+
+function getDeepData (keyList, viewData) {
+  if (keyList.length > 1) {
+    const _key = keyList.splice(0, 1)
+    const _viewData = viewData[_key]
+    if (_viewData) {
+      return getDeepData(keyList, _viewData)
+    } else {
+      return null
+    }
+  } else {
+    if (viewData[keyList[0]]) {
+      return viewData[keyList[0]]
+    } else {
+      return null
+    }
+  }
+}
+function compareAndSetDeepData (key, newData, vm, data) {
+  // 比较引用类型数据
+  try {
+    const keyList = key.split('.')
+    const oldData = getDeepData(keyList, vm.$root.$mp.page.__viewData__)
+    if (oldData === null || JSON.stringify(oldData) !== JSON.stringify(newData)) {
+      data[key] = newData
+    }
+  } catch (e) {
+    console.log(e, key, newData, vm)
+  }
+}
+
+function cleanKeyPath (vm) {
+  if (vm.__mpKeyPath) {
+    Object.keys(vm.__mpKeyPath).forEach((_key) => {
+      delete vm.__mpKeyPath[_key]['__keyPath']
+    })
+  }
+}
+
+function minifyDeepData (rootKey, originKey, vmData, data, _mpValueSet, vm) {
+  try {
+    if (vmData instanceof Array) {
+       // 数组
+      compareAndSetDeepData(rootKey + '.' + originKey, vmData, vm, data)
+    } else {
+      // Object
+      let __keyPathOnThis = {} // 存储这层对象的keyPath
+      if (vmData.__keyPath) {
+        // 有更新列表 ，按照更新列表更新
+        __keyPathOnThis = vmData.__keyPath
+        Object.keys(vmData).forEach((_key) => {
+          if (vmData[_key] instanceof Object) {
+            // 引用类型 递归
+            if (_key === '__keyPath') {
+              return
+            }
+            minifyDeepData(rootKey + '.' + originKey, _key, vmData[_key], data, null, vm)
+          } else {
+            // 更新列表中的 加入data
+            if (__keyPathOnThis[_key] === true) {
+              if (originKey) {
+                data[rootKey + '.' + originKey + '.' + _key] = vmData[_key]
+              } else {
+                data[rootKey + '.' + _key] = vmData[_key]
+              }
+            }
+          }
+        })
+         // 根节点可能有父子引用同一个引用类型数据，依赖树都遍历完后清理
+        vm['__mpKeyPath'] = vm['__mpKeyPath'] || {}
+        vm['__mpKeyPath'][vmData.__ob__.dep.id] = vmData
+      } else {
+        // 没有更新列表
+        compareAndSetDeepData(rootKey + '.' + originKey, vmData, vm, data)
+      }
+    }
+  } catch (e) {
+    console.log(e, rootKey, originKey, vmData, data)
+  }
+}
+
+function getRootKey (vm, rootKey) {
+  if (!vm.$parent.$attrs) {
+    rootKey = '$root.0' + ',' + rootKey
+    return rootKey
+  } else {
+    rootKey = vm.$parent.$attrs.mpcomid + ',' + rootKey
+    return getRootKey(vm.$parent, rootKey)
+  }
+}
+
+export function diffData (vm, data) {
+  const vmData = vm._data || {}
+  const vmProps = vm._props || {}
+  let rootKey = ''
+  if (!vm.$attrs) {
+    rootKey = '$root.0'
+  } else {
+    rootKey = getRootKey(vm, vm.$attrs.mpcomid)
+  }
+  Vue.nextTick(() => {
+    cleanKeyPath(vm)
+  })
+  // console.log(rootKey)
+
+    // 值类型变量不考虑优化，还是直接更新
+  const __keyPathOnThis = vmData.__keyPath || vm.__keyPath || {}
+  delete vm.__keyPath
+  delete vmData.__keyPath
+  delete vmProps.__keyPath
+  if (vm._mpValueSet === 'done') {
+    // 第二次赋值才进行缩减操作
+    Object.keys(vmData).forEach((vmDataItemKey) => {
+      if (vmData[vmDataItemKey] instanceof Object) {
+          // 引用类型
+        if (vmDataItemKey === '__keyPath') { return }
+        minifyDeepData(rootKey, vmDataItemKey, vmData[vmDataItemKey], data, vm._mpValueSet, vm)
+      } else {
+          // _data上的值属性只有要更新的时候才赋值
+        if (__keyPathOnThis[vmDataItemKey] === true) {
+          data[rootKey + '.' + vmDataItemKey] = vmData[vmDataItemKey]
+        }
+      }
+    })
+
+    Object.keys(vmProps).forEach((vmPropsItemKey) => {
+      if (vmProps[vmPropsItemKey] instanceof Object) {
+        // 引用类型
+        if (vmPropsItemKey === '__keyPath') { return }
+        minifyDeepData(rootKey, vmPropsItemKey, vmProps[vmPropsItemKey], data, vm._mpValueSet, vm)
+      } else {
+        data[rootKey + '.' + vmPropsItemKey] = vmProps[vmPropsItemKey]
+      }
+      // _props上的值属性只有要更新的时候才赋值
+    })
+
+    // 检查完data和props,最后补上_mpProps & _computedWatchers
+    const vmMpProps = vm._mpProps || {}
+    const vmComputedWatchers = vm._computedWatchers || {}
+    Object.keys(vmMpProps).forEach((mpItemKey) => {
+      data[rootKey + '.' + mpItemKey] = vmMpProps[mpItemKey]
+    })
+    Object.keys(vmComputedWatchers).forEach((computedItemKey) => {
+      data[rootKey + '.' + computedItemKey] = vmComputedWatchers[computedItemKey]
+    })
+      // 更新的时候要删除$root.0:{},否则会覆盖原正确数据
+    delete data[rootKey]
+  }
+  if (vm._mpValueSet === undefined) {
+      // 第一次设置数据成功后，标记位置true,再更新到这个节点如果没有keyPath数组认为不需要更新
+    vm._mpValueSet = 'done'
+  }
+  if (Vue.config.devtools) {
+    // console.log('更新VM节点', vm)
+    // console.log('实际传到Page.setData数据', data)
+    diffLog(data)
+  }
+}

--- a/src/platforms/mp/runtime/diff-data.js
+++ b/src/platforms/mp/runtime/diff-data.js
@@ -141,10 +141,10 @@ export function diffData (vm, data) {
     const vmMpProps = vm._mpProps || {}
     const vmComputedWatchers = vm._computedWatchers || {}
     Object.keys(vmMpProps).forEach((mpItemKey) => {
-      data[rootKey + '.' + mpItemKey] = vmMpProps[mpItemKey]
+      data[rootKey + '.' + mpItemKey] = vm[mpItemKey]
     })
     Object.keys(vmComputedWatchers).forEach((computedItemKey) => {
-      data[rootKey + '.' + computedItemKey] = vmComputedWatchers[computedItemKey]['value']
+      data[rootKey + '.' + computedItemKey] = vm[computedItemKey]
     })
       // 更新的时候要删除$root.0:{},否则会覆盖原正确数据
     delete data[rootKey]

--- a/src/platforms/mp/runtime/render.js
+++ b/src/platforms/mp/runtime/render.js
@@ -1,6 +1,8 @@
 // 节流方法，性能优化
 import { getComKey } from '../util/index'
 
+import { diffData } from './diff-data'
+
 // 全局的命名约定，为了节省编译的包大小一律采取形象的缩写，说明如下。
 // $c === $child
 // $k === $comKey
@@ -128,6 +130,8 @@ function getPage (vm) {
   return page
 }
 
+// 优化js变量动态变化时候引起全量更新
+
 // 优化每次 setData 都传递大量新数据
 export function updateDataToMP () {
   const page = getPage(this)
@@ -136,6 +140,9 @@ export function updateDataToMP () {
   }
 
   const data = formatVmData(this)
+
+  diffData(this, data)
+
   throttleSetData(page.setData.bind(page), data)
 }
 

--- a/src/platforms/mp/runtime/runtime-trace.js
+++ b/src/platforms/mp/runtime/runtime-trace.js
@@ -1,0 +1,17 @@
+import Vue from 'core/index'
+var updateDataTotal = 0 // 总共更新的数据量
+export function diffLog (updateData) {
+  updateData = JSON.stringify(updateData)
+  if (!Vue._mpvueTraceTimer) {
+    Vue._mpvueTraceTimer = setTimeout(function () {
+      clearTimeout(Vue._mpvueTraceTimer)
+      updateDataTotal = (updateDataTotal / 1024).toFixed(1)
+      console.log('这次操作引发500ms内数据更新量:' + updateDataTotal + 'kb')
+      Vue._mpvueTraceTimer = 0
+      updateDataTotal = 0
+    }, 500)
+  } else if (Vue._mpvueTraceTimer) {
+    updateData = updateData.replace(/[^\u0000-\u00ff]/g, 'aa') // 中文占2字节，中文替换成两个字母计算占用空间
+    updateDataTotal += updateData.length
+  }
+}


### PR DESCRIPTION
1、core/observer的set方法中，监听对象更新值时，用__keyPath:{key:true}方式把更新的key值绑定在vm数据对象上
2、每次真实调用setData前，用mp/runtime/diffData.js进行检查优化大小，规则有
   A.第一次vm渲染到小程序上，全量更新，并记下标志
   B.第二次及以后再更新，检查_data对象,如果有__keyPath,跟据__keyPath更新，没有
   __keyPath表示没有更新，不放到Page.setData
   B1._data遇到Object类型，检查Object类型__keyPath,存在的话深度遍历所有属性
   递归检查更新，不存在__keyPath可能是this.obj = {}重新写对象值造成set没捕捉到,
   使用脏检查和页面数据对比更新
   B2._data遇到Array类型，直接脏检查，避免数组不能记录__keyPath造成丢失
   B3._props属性由于父组件传入不走set,所以遍历_props，值类型直接更新,对象类型
   深度遍历进入步骤B1，数组进入B2
   B4.遍历上述后最终更新数据再加入_computedWatchers,_mpProps
   B5.组件树上的节点都完成更新后调用Vue.nextTick钩子，清理所有对象上的__keyPath
   为下次检查更新做准备
   C.diff优化好data后，如果在Vue.config.devtool == true时打印500ms内的更新量
   方便使用者检查页面的更新情况
   D.diff好的JSON中，删掉原来的$root.0={},只把必要的更新给Page.setData使用
3、使用效果：减少了只改动一个根节点属性却造成整个组件树的数据都传递给
   Page.setData的情况，从而减少因为setData量大引起的真机尤其安卓卡顿的情况

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
