### PR TITLE
bump prettier

### DIFF
--- a/packages/mpvue-template-compiler/build.js
+++ b/packages/mpvue-template-compiler/build.js
@@ -4352,13 +4352,18 @@ function transformObjectToString (babel$$1) {
   return { visitor: objectToStringVisitor }
 }
 
+function prettierFormat(code) {
+    return prettier.format(code, { parser: 'babylon', semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
+}
+
+
 function transformDynamicClass (staticClass, clsBinding) {
   if ( staticClass === void 0 ) staticClass = '';
 
   var result = babel.transform(("!" + clsBinding), { plugins: [transformObjectToTernaryOperator] });
   // 先实现功能，再优化代码
   // https://github.com/babel/babel/issues/7138
-  var cls = prettier.format(result.code, { semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '');
+  var cls = prettierFormat(result.code);
   return (staticClass + " {{" + cls + "}}")
 }
 
@@ -4366,7 +4371,7 @@ function transformDynamicStyle (staticStyle, styleBinding) {
   if ( staticStyle === void 0 ) staticStyle = '';
 
   var result = babel.transform(("!" + styleBinding), { plugins: [transformObjectToString] });
-  var cls = prettier.format(result.code, { semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '');
+  var cls = prettierFormat(result.code);
   return (staticStyle + " {{" + cls + "}}")
 }
 
@@ -4602,7 +4607,7 @@ var component = {
     var mpcomid = ast.mpcomid;
     var slots = ast.slots;
     if (slotName) {
-      attrsMap['data'] = "{{...$root[$k], $root}}";
+      attrsMap['data'] = "{{...$root[$p], ...$root[$k], $root}}";
       // bindedName is available when rendering slot in v-for
       var bindedName = attrsMap['v-bind:name'];
       if(bindedName) {
@@ -4851,7 +4856,7 @@ function generate$2 (obj, options) {
   if (tags.indexOf(tag) > -1 && !(children && children.length)) {
     return ("<" + tag + (attrs ? ' ' + attrs : '') + " />" + (ifConditionsArr.join('')))
   }
-  return ("<" + tag + (attrs ? ' ' + attrs : '') + ">" + (child || '') + "</" + tag + ">" + (ifConditionsArr.join('')))
+  return ("<" + tag + (attrs ? ' ' + attrs : '') + ">" + (child || '') + "</" + tag + ">" + (ifConditionsArr.join(''))).replace(/\n|\r/g, '')
 }
 
 function convertAttr (key, val) {

--- a/src/platforms/mp/compiler/codegen/convert/attrs.js
+++ b/src/platforms/mp/compiler/codegen/convert/attrs.js
@@ -5,17 +5,24 @@ import babel from 'babel-core'
 import prettier from 'prettier'
 
 import { transformObjectToTernaryOperator, transformObjectToString } from '../babel-plugins'
+
+
+function prettierFormat(code) {
+    return prettier.format(result.code, { parser: 'babylon', semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
+}
+
+
 function transformDynamicClass (staticClass = '', clsBinding) {
   const result = babel.transform(`!${clsBinding}`, { plugins: [transformObjectToTernaryOperator] })
   // 先实现功能，再优化代码
   // https://github.com/babel/babel/issues/7138
-  const cls = prettier.format(result.code, { semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
+  const cls = prettierFormat(code)
   return `${staticClass} {{${cls}}}`
 }
 
 function transformDynamicStyle (staticStyle = '', styleBinding) {
   const result = babel.transform(`!${styleBinding}`, { plugins: [transformObjectToString] })
-  const cls = prettier.format(result.code, { semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
+  const cls = prettierFormat(code)
   return `${staticStyle} {{${cls}}}`
 }
 

--- a/src/platforms/mp/compiler/codegen/convert/attrs.js
+++ b/src/platforms/mp/compiler/codegen/convert/attrs.js
@@ -8,7 +8,7 @@ import { transformObjectToTernaryOperator, transformObjectToString } from '../ba
 
 
 function prettierFormat(code) {
-    return prettier.format(result.code, { parser: 'babylon', semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
+    return prettier.format(code, { parser: 'babylon', semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
 }
 
 
@@ -16,13 +16,13 @@ function transformDynamicClass (staticClass = '', clsBinding) {
   const result = babel.transform(`!${clsBinding}`, { plugins: [transformObjectToTernaryOperator] })
   // 先实现功能，再优化代码
   // https://github.com/babel/babel/issues/7138
-  const cls = prettierFormat(code)
+  const cls = prettierFormat(result.code)
   return `${staticClass} {{${cls}}}`
 }
 
 function transformDynamicStyle (staticStyle = '', styleBinding) {
   const result = babel.transform(`!${styleBinding}`, { plugins: [transformObjectToString] })
-  const cls = prettierFormat(code)
+  const cls = prettierFormat(result.code)
   return `${staticStyle} {{${cls}}}`
 }
 

--- a/src/platforms/mp/compiler/codegen/generate.js
+++ b/src/platforms/mp/compiler/codegen/generate.js
@@ -22,7 +22,7 @@ export default function generate (obj, options = {}) {
   if (tags.indexOf(tag) > -1 && !(children && children.length)) {
     return `<${tag}${attrs ? ' ' + attrs : ''} />${ifConditionsArr.join('')}`
   }
-  return `<${tag}${attrs ? ' ' + attrs : ''}>${child || ''}</${tag}>${ifConditionsArr.join('')}`
+  return `<${tag}${attrs ? ' ' + attrs : ''}>${child || ''}</${tag}>${ifConditionsArr.join('')}`.replace(/\n|\r/g, '')
 }
 
 function convertAttr (key, val) {

--- a/test/mp/compiler/index.spec.js
+++ b/test/mp/compiler/index.spec.js
@@ -535,7 +535,7 @@ describe('slot', () => {
   it('插槽', () => {
     assertCodegen(
       `<div><slot>test</slot></div>`,
-      `<template name="a"><view class="_div testModuleId"><template name="default">test</template><template data="{{...$root[$k], $root}}" is="{{$slotdefault || 'default'}}"></template></view></template>`,
+      `<template name="a"><view class="_div testModuleId"><template name="default">test</template><template data="{{...$root[$p], ...$root[$k], $root}}" is="{{$slotdefault || 'default'}}"></template></view></template>`,
       {
         name: 'a',
         moduleId: 'testModuleId'
@@ -546,7 +546,7 @@ describe('slot', () => {
   it('使用', () => {
     assertCodegen(
       `<div><slot name="w">test</slot></div>`,
-      `<template name="a"><view class="_div"><template name="w">test</template><template data="{{...$root[$k], $root}}" is="{{$slotw || 'w'}}"></template></view></template>`,
+      `<template name="a"><view class="_div"><template name="w">test</template><template data="{{...$root[$p], ...$root[$k], $root}}" is="{{$slotw || 'w'}}"></template></view></template>`,
       {
         name: 'a'
       }
@@ -556,7 +556,7 @@ describe('slot', () => {
   it('含`:name`的插槽组件', () => {
     assertCodegen(
       `<div><slot :name="tab.key">test</slot></div>`,
-      `<template name="a"><view class="_div"><template name="default">test</template><template data="{{...$root[$k], $root}}" is="{{$for[tab.key]}}"></template></view></template>`,
+      `<template name="a"><view class="_div"><template name="default">test</template><template data="{{...$root[$p], ...$root[$k], $root}}" is="{{$for[tab.key]}}"></template></view></template>`,
       {
         name: 'a'
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4198,6 +4198,11 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.11.1:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
+  integrity sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

小程序使用的prettier升级到 prettier1.15用来后，出现了2个问题

1. 构建的时候warning, 

> No parser and no filepath given, using 'babylon' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.

可以指定parser解决

2. prettier[格式化vue代码](https://prettier.io/blog/2018/11/07/1.15.0.html)时可能会在`{{}}`中间增加换行符，造成小程序解析错误， 需要在生成的wxml的时候去掉

![image](https://user-images.githubusercontent.com/3983408/48458495-8c39a700-e801-11e8-9ee5-846b692e76c8.png)

