### PR TITLE
bump prettier

### DIFF
--- a/src/platforms/mp/compiler/codegen/convert/attrs.js
+++ b/src/platforms/mp/compiler/codegen/convert/attrs.js
@@ -5,17 +5,23 @@ import babel from 'babel-core'
 import prettier from 'prettier'
 
 import { transformObjectToTernaryOperator, transformObjectToString } from '../babel-plugins'
+
+
+function prettierFormat(code) {
+    return prettier.format(code, { parser: 'babylon', semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
+}
+
 function transformDynamicClass (staticClass = '', clsBinding) {
   const result = babel.transform(`!${clsBinding}`, { plugins: [transformObjectToTernaryOperator] })
   // 先实现功能，再优化代码
   // https://github.com/babel/babel/issues/7138
-  const cls = prettier.format(result.code, { semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
+  const cls = prettierFormat(result.code)
   return `${staticClass} {{${cls}}}`
 }
 
 function transformDynamicStyle (staticStyle = '', styleBinding) {
   const result = babel.transform(`!${styleBinding}`, { plugins: [transformObjectToString] })
-  const cls = prettier.format(result.code, { semi: false, singleQuote: true }).slice(1).slice(0, -1).replace(/\n|\r/g, '')
+  const cls = prettierFormat(result.code)
   return `${staticStyle} {{${cls}}}`
 }
 

--- a/src/platforms/mp/compiler/codegen/generate.js
+++ b/src/platforms/mp/compiler/codegen/generate.js
@@ -19,10 +19,13 @@ export default function generate (obj, options = {}) {
   const attrs = Object.keys(attrsMap).map(k => convertAttr(k, attrsMap[k])).join(' ')
 
   const tags = ['progress', 'checkbox', 'switch', 'input', 'radio', 'slider', 'textarea']
+  let generatedCode
   if (tags.indexOf(tag) > -1 && !(children && children.length)) {
-    return `<${tag}${attrs ? ' ' + attrs : ''} />${ifConditionsArr.join('')}`
+    generatedCode =  `<${tag}${attrs ? ' ' + attrs : ''} />${ifConditionsArr.join('')}`
+  } else {
+    generatedCode = `<${tag}${attrs ? ' ' + attrs : ''}>${child || ''}</${tag}>${ifConditionsArr.join('')}`
   }
-  return `<${tag}${attrs ? ' ' + attrs : ''}>${child || ''}</${tag}>${ifConditionsArr.join('')}`
+  return generatedCode.replace(/\n|\r/g, '')
 }
 
 function convertAttr (key, val) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

小程序使用的prettier升级到 prettier1.15用来后，出现了2个问题

1. 构建的时候warning, 

> No parser and no filepath given, using 'babylon' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.

可以指定parser解决

2. prettier[格式化vue代码](https://prettier.io/blog/2018/11/07/1.15.0.html)时可能会在`{{}}`中间增加换行符，造成小程序解析错误， 需要在生成的wxml的时候去掉换行符

![image](https://user-images.githubusercontent.com/3983408/48458495-8c39a700-e801-11e8-9ee5-846b692e76c8.png)

不需要在`package.json`中升级prettier的版本，因为parser参数一直是有效的