### PR TITLE
feat: cover-view子元素编译成cover-view

### DIFF
--- a/packages/mpvue-template-compiler/build.js
+++ b/packages/mpvue-template-compiler/build.js
@@ -4602,7 +4602,7 @@ var component = {
     var mpcomid = ast.mpcomid;
     var slots = ast.slots;
     if (slotName) {
-      attrsMap['data'] = "{{...$root[$k], $root}}";
+      attrsMap['data'] = "{{...$root[$p], ...$root[$k], $root}}";
       // bindedName is available when rendering slot in v-for
       var bindedName = attrsMap['v-bind:name'];
       if(bindedName) {
@@ -4620,6 +4620,12 @@ var component = {
   }
 };
 
+var coverViewTagMap = {
+  'view': 'cover-view',
+  'label': 'cover-view',
+  'image': 'cover-image'
+};
+
 var tag = function (ast, options) {
   var tag = ast.tag;
   var elseif = ast.elseif;
@@ -4628,6 +4634,7 @@ var tag = function (ast, options) {
   var staticClass = ast.staticClass; if ( staticClass === void 0 ) staticClass = '';
   var attrsMap = ast.attrsMap; if ( attrsMap === void 0 ) attrsMap = {};
   var components = options.components;
+  var isCoverView = options.isCoverView;
   var ifText = attrsMap['v-if'];
   var href = attrsMap.href;
   var bindHref = attrsMap['v-bind:href'];
@@ -4671,6 +4678,10 @@ var tag = function (ast, options) {
       });
       delete ast.attrsMap.value;
     }
+  }
+
+  if (isCoverView) {
+    ast.tag = coverViewTagMap[ast.tag] || ast.tag;
   }
   return ast
 };
@@ -4781,6 +4792,9 @@ function convertAst (node, options, util) {
   }
 
   wxmlAst.attrsMap = attrs.format(wxmlAst.attrsMap);
+  if (wxmlAst.tag === 'cover-view') {
+    options.isCoverView = true;
+  }
   wxmlAst = tag(wxmlAst, options);
   wxmlAst = convertFor(wxmlAst, options);
   wxmlAst = attrs.convertAttr(wxmlAst, log);

--- a/src/platforms/mp/compiler/codegen/convert/index.js
+++ b/src/platforms/mp/compiler/codegen/convert/index.js
@@ -68,6 +68,9 @@ function convertAst (node, options = {}, util) {
   }
 
   wxmlAst.attrsMap = attrs.format(wxmlAst.attrsMap)
+  if (wxmlAst.tag === 'cover-view') {
+    options.isCoverView = true
+  }
   wxmlAst = tag(wxmlAst, options)
   wxmlAst = convertFor(wxmlAst, options)
   wxmlAst = attrs.convertAttr(wxmlAst, log)

--- a/src/platforms/mp/compiler/codegen/convert/tag.js
+++ b/src/platforms/mp/compiler/codegen/convert/tag.js
@@ -1,9 +1,15 @@
 import component from './component'
 import tagMap from '../config/wxmlTagMap'
 
+const coverViewTagMap = {
+  'view': 'cover-view',
+  'label': 'cover-view',
+  'image': 'cover-image'
+}
+
 export default function (ast, options) {
   const { tag, elseif, else: elseText, for: forText, staticClass = '', attrsMap = {}} = ast
-  const { components } = options
+  const { components, isCoverView } = options
   const { 'v-if': ifText, href, 'v-bind:href': bindHref, name } = attrsMap
 
   if (!tag) {
@@ -44,6 +50,10 @@ export default function (ast, options) {
       })
       delete ast.attrsMap.value
     }
+  }
+
+  if (isCoverView) {
+    ast.tag = coverViewTagMap[ast.tag] || ast.tag
   }
   return ast
 }

--- a/test/mp/compiler/index.spec.js
+++ b/test/mp/compiler/index.spec.js
@@ -640,6 +640,16 @@ describe('web-view', () => {
   })
 })
 
+describe('cover-view', () => {
+  it('cover-view', () => {
+    assertCodegen(
+      `<cover-view><span></span><div><img src="testPath"></div><cover-img></cover-img><cover-view></cover-view></cover-view>`,
+      `<template name="a"><cover-view class="_cover-view"><cover-view class="_span"></cover-view><cover-view class="_div"><cover-image src="testPath" class="_img"></cover-image></cover-view><cover-img class="_cover-img"></cover-img><cover-view class="_cover-view"></cover-view></cover-view></template>`,
+      { name: 'a' }
+    )
+  })
+})
+
 describe('组件', () => {
   it('组件驼峰命名', () => {
     assertCodegen(


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

会把所有cover-view的子元素都编译成cover-view，理论上对合理使用cover-view的用户无影响。

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

https://github.com/Meituan-Dianping/mpvue/issues/1215

**Other information:**
