### PR TITLE
slot基础上支持 slot-scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ packages/vue-server-renderer/server-plugin.js
 packages/vue-server-renderer/client-plugin.js
 packages/vue-template-compiler/build.js
 .vscode/
+.idea/

--- a/packages/mpvue-template-compiler/build.js
+++ b/packages/mpvue-template-compiler/build.js
@@ -4747,19 +4747,27 @@ var component = {
           var name = ref.name;
           var value = ref.value;
 
-          if (name.startsWith('v-bind')) {
-            var bindTarget = name.slice('v-bind'.length + 1);
-            var pathStr = genKeyStr(value);
-            var varSep = pathStr[0] === '[' ? '' : '.';
-            var bindValStr = varRootStr + varSep + pathStr + ' ,';
-            if (!bindTarget) {
-              $scopeStr += '...' + bindValStr;
-            } else {
-              $scopeStr += bindTarget + ': ' + bindValStr;
-            }
+          var bindTarget = false;
+          if (name.startsWith(':')) {
+            bindTarget = name.slice(1);
+          } else if (name.startsWith('v-bind')) {
+            bindTarget = name.slice('v-bind'.length + 1);
+          }
+          if (!bindTarget === false) { return }
+          var pathStr = genKeyStr(value);
+          // 区分取变量方式：$root[$k].data 或 $root[$k][idx]
+          var varSep = pathStr[0] === '[' ? '' : '.';
+          var bindValStr = varRootStr + varSep + pathStr + ' ,';
+          if (bindTarget === '') {
+            // v-bind="data" 情况
+            $scopeStr += '...' + bindValStr;
+          } else {
+            // v-bind:something="varible" 情况
+            $scopeStr += bindTarget + ': ' + bindValStr;
           }
         });
         $scopeStr = $scopeStr.replace(/,?$/, ' }');
+        // 约定使用 '$scopedata' 为替换变量名
         attrsMap['data'] = "{{ ...$root[$p], ...$root[$k], $root, $scopedata: " + $scopeStr + " }}";
       } else {
         attrsMap['data'] = '{{...$root[$p], ...$root[$k], $root}}';

--- a/packages/mpvue-template-compiler/build.js
+++ b/packages/mpvue-template-compiler/build.js
@@ -2261,12 +2261,14 @@ function processSlot (el) {
       );
     }
   } else {
+    // 添加slotScope属性，vue 2.5+
+    el.slotScope = getAndRemoveAttr(el, 'slot-scope');
     var slotTarget = getBindingAttr(el, 'slot');
     if (slotTarget) {
       el.slotTarget = slotTarget === '""' ? '"default"' : slotTarget;
-    }
-    if (el.tag === 'template') {
-      el.slotScope = getAndRemoveAttr(el, 'scope');
+      if (el.tag !== 'template' && !el.slotScope) {
+        addAttr(el, 'slot', slotTarget);
+      }
     }
   }
 }
@@ -2920,8 +2922,6 @@ function defineReactive$$1 (
     return
   }
 
-  // TODO: 先试验标记一下 keyPath
-
   // cater for pre-defined getter/setters
   var getter = property && property.get;
   var setter = property && property.set;
@@ -2995,8 +2995,10 @@ function set (target, key, val) {
     return val
   }
   defineReactive$$1(ob.value, key, val);
-  // Vue.set 添加对象属性，渲染时候把val传给小程序渲染
-  target.__keyPath = target.__keyPath ? target.__keyPath : {};
+  // Vue.set 添加对象属性，渲染时候把 val 传给小程序渲染
+  if (!target.__keyPath) {
+    target.__keyPath = {};
+  }
   target.__keyPath[key] = true;
   ob.dep.notify();
   return val
@@ -3559,7 +3561,7 @@ function genScopedSlot (
   if (el.for && !el.forProcessed) {
     return genForScopedSlot(key, el, state)
   }
-  return "{key:" + key + ",fn:function(" + (String(el.attrsMap.scope)) + "){" +
+  return "{key:" + key + ",fn:function(" + (String(el.slotScope)) + "){" +
     "return " + (el.tag === 'template'
       ? genChildren(el, state) || 'void 0'
       : genElement(el, state)) + "}}"
@@ -4576,6 +4578,119 @@ var attrs = {
   }
 };
 
+/**
+ * 替换模板中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+var replaceVarSimple = function (alias, aliasFull) { return function (str) { return str
+    .replace(new RegExp(("^" + alias + "$")), aliasFull)
+    .replace(new RegExp(("\\." + alias + "\\."), 'g'), ("." + aliasFull + "."))
+    .replace(new RegExp(("'" + alias + "'"), 'g'), ("'" + aliasFull + "'"))
+    .replace(new RegExp(("^" + alias + "\\.")), (aliasFull + "."))
+    .replace(new RegExp(("\\." + alias + "$")), ("." + aliasFull)); }; };
+/**
+ * 替换 astMap 属性中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+var replaceSlotScopeVar = function (alias, aliasFull) { return function (str) { return str
+    .replace(new RegExp(("^" + alias + "$")), aliasFull)
+    .replace(new RegExp(("^" + alias + "\\.")), (aliasFull + ".")); }; };
+/**
+ * 替换 astMap 静态模板部分中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+var replaceTemplateVar = function (alias, aliasFull) { return function (str) {
+  var result = str
+    .replace(new RegExp(("^\\(" + alias + "\\)"), 'g'), ("(" + aliasFull + ")"))
+    .replace(new RegExp(("^\\(" + alias + "\\."), 'g'), ("(" + aliasFull + "."));
+  return result
+}; };
+/**
+ * 使用替换参数创建一个用于生成{expression, text}的方法，简化调用
+ * @param {string} target 模板变量名
+ * @param {string} using 约定变量名
+ * @returns { expression, text }
+ */
+var expressionReplacerFactory = function (
+  target,
+  using
+) {
+  if ( using === void 0 ) using = '$scopedata';
+
+  return function (expression) {
+  var arr = expression.split(/(\(.*?\))/g);
+  var textArr = arr.slice();
+  var replacer = replaceTemplateVar(target, using);
+  var result = arr
+    .map(function (str, idx) {
+      if (!/^\(.*?\)$/.test(str)) { return }
+      var mainStr = replacer(str);
+      textArr[idx] = "(`" + (mainStr.slice(1, mainStr.length - 1)) + "`)";
+      return ("" + (replacer(str)))
+    })
+    .join('');
+  var text = '';
+  var _s = function (str) { return ("{{ " + str + " }}"); };
+  try {
+    text = eval(textArr.join('').replace(/\n/g, '\\n'));
+  } catch (e) {
+    console.info(_s(text), e);
+  }
+  return { expression: result, text: text }
+};
+};
+
+/**
+ * 替换当前节点属性、静态模板中使用的作用域变量，如果有
+ * @param { astNode } nodeAst 节点词法树
+ */
+var replaceVarStr = function (nodeAst, options) {
+  if ( options === void 0 ) options = {};
+
+  var replaceTarget = options.replaceTarget;
+  if (!replaceTarget) { return nodeAst }
+  var replacer = replaceSlotScopeVar(replaceTarget, '$scopedata');
+  var expressionReplacer = expressionReplacerFactory(
+    replaceTarget,
+    '$scopedata'
+  );
+  var cache = {};
+  var attrs = nodeAst.attrs; if ( attrs === void 0 ) attrs = [];
+  var attrsList = nodeAst.attrsList; if ( attrsList === void 0 ) attrsList = [];
+  var attrsMap = nodeAst.attrsMap; if ( attrsMap === void 0 ) attrsMap = {};
+  var getValueWithCache = function (oriValue) {
+    var value;
+    if (cache[oriValue] !== undefined) {
+      value = cache[oriValue];
+    } else {
+      value = replacer(oriValue);
+      cache[oriValue] = value;
+    }
+    return value
+  };
+  var mapFn = function (item) { return Object.assign({}, item, { value: getValueWithCache(item.value) }); };
+  attrs = attrs.map(mapFn);
+  attrsList = attrsList.map(mapFn);
+  var newMap = {};
+  Object.keys(attrsMap).forEach(function (key) {
+    if (!key.startsWith(':')) { return }
+    newMap[key] = getValueWithCache(attrsMap[key]);
+  });
+  var newNode = Object.assign({}, nodeAst, { attrs: attrs, attrsList: attrsList, attrsMap: newMap });
+  // 替换静态内容
+  if (newNode.expression) {
+    var ref = expressionReplacer(newNode.expression);
+    var expression = ref.expression;
+    var text = ref.text;
+    newNode.expression = expression;
+    newNode.text = text || newNode.text;
+  }
+  return newNode
+};
+
 function getSlotsName (obj) {
   if (!obj) {
     return ''
@@ -4614,8 +4729,41 @@ var component = {
     var tag = ast.tag;
     var mpcomid = ast.mpcomid;
     var slots = ast.slots;
+    var attrsList = ast.attrsList;
     if (slotName) {
-      attrsMap['data'] = "{{...$root[$k], $root}}";
+      var ref = ast.parent;
+      var alias = ref.alias;
+      var forName = ref.for;
+      var iterator1 = ref.iterator1;
+      var hasFor = forName && alias;
+      // 有 v-for 的slot-scoped 在原有的 <template data=‘... 上增加作用域数据
+      if (hasFor) {
+        // scope-slot 情况
+        var varRootStr = '$root[$k]';
+        var aliasFull = "['" + forName + "'][" + iterator1 + "]";
+        var $scopeStr = '{ ';
+        var genKeyStr = replaceVarSimple(alias, aliasFull);
+        attrsList.forEach(function (ref) {
+          var name = ref.name;
+          var value = ref.value;
+
+          if (name.startsWith('v-bind')) {
+            var bindTarget = name.slice('v-bind'.length + 1);
+            var pathStr = genKeyStr(value);
+            var varSep = pathStr[0] === '[' ? '' : '.';
+            var bindValStr = varRootStr + varSep + pathStr + ' ,';
+            if (!bindTarget) {
+              $scopeStr += '...' + bindValStr;
+            } else {
+              $scopeStr += bindTarget + ': ' + bindValStr;
+            }
+          }
+        });
+        $scopeStr = $scopeStr.replace(/,?$/, ' }');
+        attrsMap['data'] = "{{ ...$root[$p], ...$root[$k], $root, $scopedata: " + $scopeStr + " }}";
+      } else {
+        attrsMap['data'] = '{{...$root[$p], ...$root[$k], $root}}';
+      }
       // bindedName is available when rendering slot in v-for
       var bindedName = attrsMap['v-bind:name'];
       if(bindedName) {
@@ -4641,6 +4789,7 @@ var tag = function (ast, options) {
   var staticClass = ast.staticClass; if ( staticClass === void 0 ) staticClass = '';
   var attrsMap = ast.attrsMap; if ( attrsMap === void 0 ) attrsMap = {};
   var components = options.components;
+  var fromSlotScope = options.fromSlotScope;
   var ifText = attrsMap['v-if'];
   var href = attrsMap.href;
   var bindHref = attrsMap['v-bind:href'];
@@ -4655,11 +4804,12 @@ var tag = function (ast, options) {
   }
   ast.tag = tagMap[tag] || tag;
 
-  var isSlot = tag === 'slot';
+  var isSlot = tag === 'slot' || ast.slotScope;
 
   if ((ifText || elseif || elseText || forText) && tag === 'template') {
     ast.tag = 'block';
-  } else if (isComponent || isSlot) {
+  } else if (isComponent || (isSlot && !fromSlotScope)) {
+    // scopedSlot 会迭代 普通slot的方法，不需要再用template替换，视为普通view
     var originSlotName = name || 'default';
     var slotName = isSlot ? ("$slot" + originSlotName + " || '" + originSlotName + "'") : undefined;
 
@@ -4733,10 +4883,19 @@ function convertAst (node, options, util) {
   var deps = util.deps;
   var slots = util.slots;
   var slotTemplates = util.slotTemplates;
+  var scopedSlots = util.scopedSlots;
   var wxmlAst = Object.assign({}, node);
   var moduleId = options.moduleId;
   var components = options.components;
   wxmlAst.tag = tagName = tagName ? hyphenate(tagName) : tagName;
+  // 跟随迭代过程，保留slotScope变量名，用于 slot.wxml 中替换变量名，以实现于vue slot-scope 变量使用一致
+  var replaceTarget = options.fromSlotScope;
+  if (typeof replaceTarget !== 'string') {
+    replaceTarget = false;
+  }
+  // 自身没有作用域属性，从上级取
+  replaceTarget = replaceTarget || options.replaceTarget;
+
   // 引入 import, isSlot 是使用 slot 的编译地方，意即 <slot></slot> 的地方
   var isSlot = tagName === 'slot';
   if (isSlot) {
@@ -4764,6 +4923,24 @@ function convertAst (node, options, util) {
 
   // 组件内部的node节点全部是 slot
   wxmlAst.slots = {};
+
+  // 处理 scopedSlot，跟slot逻辑一致，使用普通slot的缓存变量
+  var srcScoped = Object.assign({}, node.scopedSlots);
+  Object.keys(srcScoped).forEach(function (key) {
+    var item = Object.assign({}, srcScoped[key]);
+    var multiItem = Array.isArray(item);
+    var slotName = (item.attrsMap && item.attrsMap.slot) || 'default';
+    var isDefault = slotName === 'default';
+    var slotId = moduleId + "-" + slotName + "-" + (mpcomid.replace(/\'/g, ''));
+    // 子组件标识 fromSlotScope
+    var children = (multiItem ? item : [item]);
+    var node = isDefault ? { tag: 'template', attrsMap: {}, children: children } : item;
+    node.attrsMap.name = slotId;
+    delete node.attrsMap.slot;
+    scopedSlots[slotId] = { node: convertAst(node, Object.assign({}, options, { fromSlotScope: item.slotScope || true }), util), name: slotName, slotId: slotId };
+    wxmlAst.slots[slotName] = slotId;
+  });
+
   if (currentIsComponent && children && children.length) {
     // 只检查组件下的子节点（不检查孙子节点）是不是具名 slot，不然就是 default slot
     children
@@ -4798,7 +4975,13 @@ function convertAst (node, options, util) {
   wxmlAst = convertFor(wxmlAst, options);
   wxmlAst = attrs.convertAttr(wxmlAst, log);
   if (children && !isSlot) {
-    wxmlAst.children = children.map(function (k) { return convertAst(k, options, util); });
+    // 中转 scopedSlot，可能得到空children，进行过滤
+    wxmlAst.children = children.filter(function (_) { return _; }).map(function (k) {
+      /** 向下迭代 replaceTarget， 用于标识作用域模板中可替换的变量
+       *  replaceVarStr 替换astNode中属性text等绑定变量的作用域变量*/
+      var nextOptions = Object.assign({}, options, { replaceTarget: replaceTarget });
+      return convertAst(replaceVarStr(k, nextOptions), nextOptions, util)
+    });
   }
 
   if (ifConditions) {
@@ -4821,16 +5004,22 @@ function wxmlAst (compiled, options, log) {
   var slots = {
     // slotId: nodeAst
   };
+
+  var scopedSlots = {
+    // slotId: scopedSlots
+  };
+
   var slotTemplates = {
   };
 
-  var wxast = convertAst(ast, options, { log: log, deps: deps, slots: slots, slotTemplates: slotTemplates });
-  var children = Object.keys(slotTemplates).map(function (k) { return convertAst(slotTemplates[k], options, { log: log, deps: deps, slots: slots, slotTemplates: slotTemplates }); });
+  var wxast = convertAst(ast, options, { log: log, deps: deps, slots: slots, scopedSlots: scopedSlots, slotTemplates: slotTemplates });
+  var children = Object.keys(slotTemplates).map(function (k) { return convertAst(slotTemplates[k], options, { log: log, deps: deps, slots: slots, scopedSlots: scopedSlots, slotTemplates: slotTemplates }); });
   wxast.children = children.concat(wxast.children);
   return {
     wxast: wxast,
     deps: deps,
-    slots: slots
+    slots: slots,
+    scopedSlots: scopedSlots
   }
 }
 
@@ -4905,6 +5094,7 @@ function compileToWxml (compiled, options) {
   var wxast = ref.wxast;
   var deps = ref.deps; if ( deps === void 0 ) deps = {};
   var slots = ref.slots; if ( slots === void 0 ) slots = {};
+  var scopedSlots = ref.scopedSlots; if ( scopedSlots === void 0 ) scopedSlots = {};
   var code = generate$2(wxast, options);
 
   // 引用子模版
@@ -4917,8 +5107,13 @@ function compileToWxml (compiled, options) {
     slot.code = generate$2(slot.node, options);
   });
 
+  // 生成 scoped slot code
+  Object.keys(scopedSlots).forEach(function (k) {
+    var slot = scopedSlots[k];
+    slot.code = generate$2(slot.node, options);
+  });
   // TODO: 后期优化掉这种暴力全部 import，虽然对性能没啥大影响
-  return { code: code, compiled: compiled, slots: slots, importCode: importCode }
+  return { code: code, compiled: compiled, slots: slots, scopedSlots: scopedSlots, importCode: importCode }
 }
 
 /*  */

--- a/packages/mpvue-template-compiler/package.json
+++ b/packages/mpvue-template-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpvue-template-compiler",
-  "version": "1.0.13",
+  "version": "1.0.18",
   "description": "mpvue template compiler for Vue",
   "main": "index.js",
   "repository": {

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -342,7 +342,7 @@ function genScopedSlot (
   if (el.for && !el.forProcessed) {
     return genForScopedSlot(key, el, state)
   }
-  return `{key:${key},fn:function(${String(el.attrsMap.scope)}){` +
+  return `{key:${key},fn:function(${String(el.slotScope)}){` +
     `return ${el.tag === 'template'
       ? genChildren(el, state) || 'void 0'
       : genElement(el, state)

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -33,7 +33,7 @@ export class CodegenState {
 }
 
 export type WithLast = {
-  added: Boolean
+  needSuffix: Boolean
 }
 
 export type CodegenResult = {
@@ -349,7 +349,7 @@ function genScopedSlot (
     `const _last = ${el.slotScope}.mpcomidx === undefined ? '' : 'v' + ${el.slotScope}.mpcomidx;\n` +
     `return ${el.tag === 'template'
       ? genChildren(el, state) || 'void 0'
-      : genElement(el, state, { added: true })
+      : genElement(el, state, { needSuffix: true })
   }}}`
 }
 
@@ -375,7 +375,7 @@ export function genChildren (
   checkSkip?: boolean,
   altGenElement?: Function,
   altGenNode?: Function,
-  withLast?: Boolean
+  withLast?: WithLast
 ): string | void {
   const children = el.children
   if (children.length) {
@@ -392,7 +392,7 @@ export function genChildren (
       ? getNormalizationType(children, state.maybeComponent)
       : 0
     const gen = altGenNode || genNode
-    return `[${children.map(c => gen(c, state, withLast)).join(',')}]${
+    return `[${children.map(c => gen(c, state, Object.assign({}, withLast))).join(',')}]${
       normalizationType ? `,${normalizationType}` : ''
     }`
   }
@@ -487,14 +487,14 @@ function genProps (props: Array<{ name: string, value: string }>, withLast: With
   for (let i = 0; i < props.length; i++) {
     const prop = props[i]
     res += `"${prop.name}":${transformSpecialNewlines(prop.value)}`
-    if (!withLast.added && prop.name === 'mpcomid') {
+    if (withLast && withLast.needSuffix && prop.name === 'mpcomid') {
       consumed = true
       res += '+_last '
     }
     res += ','
   }
   if (consumed) {
-    withLast.added = true
+    withLast.needSuffix = false
   }
   return res.slice(0, -1)
 }

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -428,12 +428,14 @@ function processSlot (el) {
       )
     }
   } else {
-    const slotTarget = getBindingAttr(el, 'slot')
+    // 添加slotScope属性，vue 2.5+
+    el.slotScope = getAndRemoveAttr(el, 'slot-scope')
+    var slotTarget = getBindingAttr(el, 'slot')
     if (slotTarget) {
       el.slotTarget = slotTarget === '""' ? '"default"' : slotTarget
-    }
-    if (el.tag === 'template') {
-      el.slotScope = getAndRemoveAttr(el, 'scope')
+      if (el.tag !== 'template' && !el.slotScope) {
+        addAttr(el, 'slot', slotTarget)
+      }
     }
   }
 }

--- a/src/platforms/mp/compiler/codegen/convert/component.js
+++ b/src/platforms/mp/compiler/codegen/convert/component.js
@@ -1,4 +1,4 @@
-import { replaceVarSimple } from '../utils.scopeslot'
+import { replaceVarSimple, getBindings, getClosestFor } from '../utils.scopeslot'
 
 function getSlotsName (obj) {
   if (!obj) {
@@ -20,7 +20,7 @@ function tmplateSlotsObj(obj) {
   }
   // wxml模板中 data="{{ a:{a1:'string2'}, b:'string'}}" 键a1不能写成 'a1' 带引号的形式，会出错
   const $for = Object.keys(obj)
-    .map(function(k) {
+    .map(k => {
       return `${k}:'${obj[k]}'`
     })
     .join(',')
@@ -34,47 +34,60 @@ export default {
   convertComponent (ast, components, slotName) {
     const { attrsMap, tag, mpcomid, slots, attrsList } = ast
     if (slotName) {
-      const { alias, for: forName, iterator1 } = ast.parent
-      const hasFor = forName && alias
-      // 有 v-for 的slot-scoped 在原有的 <template data=‘... 上增加作用域数据
-      if (hasFor) {
-        // scope-slot 情况
+      // 检查插槽是否含有绑定数据
+      const hasDataBinding = getBindings(ast.attrsList).length
+      const closestForNode = getClosestFor(ast)
+      if (hasDataBinding) {
+        let genKeyStr = v => v
+        if (closestForNode) {
+          // 有 v-for 场景，替换模板中约定的slot-scope。因slot只有一份，采用slot-scope统一成一个的处理方式
+          const { alias, for: forName, iterator1 } = closestForNode
+          const aliasFull = `${forName}[${iterator1}]`
+          genKeyStr = replaceVarSimple(alias, aliasFull)
+        }
         const varRootStr = '$root[$k]'
-        const aliasFull = `['${forName}'][${iterator1}]`
         let $scopeStr = '{ '
-        const genKeyStr = replaceVarSimple(alias, aliasFull)
-        attrsList.forEach(function ({ name, value }) {
+        attrsList.forEach(({ name, value }) => {
           let bindTarget = false
           if (name.startsWith(':')) {
             bindTarget = name.slice(1)
           } else if (name.startsWith('v-bind')) {
             bindTarget = name.slice('v-bind'.length + 1)
+          } else {
+            // 非动态绑定attr
+            $scopeStr += `name: '${value}' ,`
           }
           if (bindTarget === false) return
           const pathStr = genKeyStr(value)
           // 区分取变量方式：$root[$k].data 或 $root[$k][idx]
           const varSep = pathStr[0] === '[' ? '' : '.'
-          const bindValStr = varRootStr + varSep + pathStr + ' ,'
+          const bindValStr = `${varRootStr}${varSep}${pathStr} ,`
           if (bindTarget === '') {
             // v-bind="data" 情况
-            $scopeStr += '...' + bindValStr
+            $scopeStr += `...${bindValStr}`
           } else {
             // v-bind:something="varible" 情况
-            $scopeStr += bindTarget + ': ' + bindValStr
+            $scopeStr += `${bindTarget}: ${bindValStr}`
           }
         })
         $scopeStr = $scopeStr.replace(/,?$/, ' }')
-        // 约定使用 '$scopedata' 为替换变量名
+        // 有 slot-scoped 在原有的 <template data=‘... 上增加作用域数据，约定使用 '$scopedata' 为替换变量名
         attrsMap['data'] = `{{ ...$root[$p], ...$root[$k], $root, $scopedata: ${$scopeStr} }}`
       } else {
         attrsMap['data'] = '{{...$root[$p], ...$root[$k], $root}}'
       }
-      // bindedName is available when rendering slot in v-for
+      // slotAst 的 'v-bind:name' 不会在attrsList中出现，以此判断当前slot绑定了动态 name
       const bindedName = attrsMap['v-bind:name']
-      if(bindedName) {
-        attrsMap['is'] = "{{$for[" + bindedName + "]}}"
+      if (bindedName) {
+        const alias = closestForNode && closestForNode.alias
+        // 如果 slot[:name] 在v-for作用域里
+        if (alias && bindedName.startsWith(alias) && ['.', '', undefined].includes(bindedName[alias.length])) {
+          attrsMap['is'] = `{{$for[${bindedName}] || 'default'}}`
+        } else {
+          attrsMap['is'] = `{{ $for[$root[$k].${bindedName}] || 'default' }}`
+        }
       } else {
-        attrsMap['is'] = "{{" + slotName + "}}"
+        attrsMap['is'] = `{{${slotName}}}`
       }
     } else {
       const slotsName = getSlotsName(slots)

--- a/src/platforms/mp/compiler/codegen/convert/component.js
+++ b/src/platforms/mp/compiler/codegen/convert/component.js
@@ -73,10 +73,16 @@ export default {
     const closestForNode = getClosestFor(ast)
     // 对于scope，手动添加一份标签上绑定的变量
     const scopeAttrs = tagBindingAttrs(attrsList, closestForNode)
-    const scopeAttrStr = scopeAttrs.length ? `,$scopedata:{${scopeAttrs.join()} }` : ''
+    let scopeAttrStr = ''
+    let scopeIdStr = ''
+    if (scopeAttrs.length) {
+      scopeAttrStr = `,$scopedata:{${scopeAttrs.join()} }`
+      // 对于scope，添加一份索引
+      scopeIdStr = closestForNode && closestForNode.iterator1 ? `,$slotidx:'v'+${closestForNode.iterator1}` : ''
+    }
     if (slotName) {
       // 有 slot-scoped 在原有的 <template data=‘... 上增加作用域数据，约定使用 '$scopedata' 为替换变量名
-      attrsMap['data'] = `{{...$root[$p], ...$root[$k], $root${scopeAttrStr} }}`
+      attrsMap['data'] = `{{...$root[$p], ...$root[$k], $root${scopeAttrStr}${scopeIdStr} }}`
       // slotAst 的 'v-bind:name' 不会在attrsList中出现，以此判断当前slot绑定了动态 name
       const bindedName = attrsMap['v-bind:name']
       if (bindedName) {
@@ -93,7 +99,7 @@ export default {
     } else {
       const slotsName = getSlotsName(slots)
       const restSlotsName = slotsName ? `, ${slotsName}` : ''
-      attrsMap['data'] = `{{...$root[$kk+${mpcomid}], $root${restSlotsName}${scopeAttrStr} }}`
+      attrsMap['data'] = `{{...$root[$kk+${mpcomid}+($slotidx || '')], $root${restSlotsName}${scopeAttrStr} }}`
       attrsMap['is'] = components[tag].name
     }
     return ast

--- a/src/platforms/mp/compiler/codegen/convert/component.js
+++ b/src/platforms/mp/compiler/codegen/convert/component.js
@@ -50,7 +50,7 @@ export default {
           } else if (name.startsWith('v-bind')) {
             bindTarget = name.slice('v-bind'.length + 1)
           }
-          if (!bindTarget === false) return
+          if (bindTarget === false) return
           const pathStr = genKeyStr(value)
           // 区分取变量方式：$root[$k].data 或 $root[$k][idx]
           const varSep = pathStr[0] === '[' ? '' : '.'

--- a/src/platforms/mp/compiler/codegen/convert/tag.js
+++ b/src/platforms/mp/compiler/codegen/convert/tag.js
@@ -2,8 +2,8 @@ import component from './component'
 import tagMap from '../config/wxmlTagMap'
 
 export default function (ast, options) {
-  const { fromSlotScope, tag, elseif, else: elseText, for: forText, staticClass = '', attrsMap = {}} = ast
-  const { components } = options
+  const { tag, elseif, else: elseText, for: forText, staticClass = '', attrsMap = {}} = ast
+  const { components, fromSlotScope } = options
   const { 'v-if': ifText, href, 'v-bind:href': bindHref, name } = attrsMap
 
   if (!tag) {

--- a/src/platforms/mp/compiler/codegen/convert/tag.js
+++ b/src/platforms/mp/compiler/codegen/convert/tag.js
@@ -2,7 +2,7 @@ import component from './component'
 import tagMap from '../config/wxmlTagMap'
 
 export default function (ast, options) {
-  const { tag, elseif, else: elseText, for: forText, staticClass = '', attrsMap = {}} = ast
+  const { fromSlotScope, tag, elseif, else: elseText, for: forText, staticClass = '', attrsMap = {}} = ast
   const { components } = options
   const { 'v-if': ifText, href, 'v-bind:href': bindHref, name } = attrsMap
 
@@ -15,11 +15,12 @@ export default function (ast, options) {
   }
   ast.tag = tagMap[tag] || tag
 
-  const isSlot = tag === 'slot'
+  const isSlot = tag === 'slot' || ast.slotScope
 
   if ((ifText || elseif || elseText || forText) && tag === 'template') {
     ast.tag = 'block'
-  } else if (isComponent || isSlot) {
+  } else if (isComponent || (isSlot && !fromSlotScope)) {
+    // scopedSlot 会迭代 普通slot的方法，不需要再用template替换，视为普通view
     const originSlotName = name || 'default'
     const slotName = isSlot ? `$slot${originSlotName} || '${originSlotName}'` : undefined
 

--- a/src/platforms/mp/compiler/codegen/generate.js
+++ b/src/platforms/mp/compiler/codegen/generate.js
@@ -1,4 +1,4 @@
-export default function generate (obj, options = {}) {
+export default function generate (obj = {}, options = {}) {
   const { tag, attrsMap = {}, children, text, ifConditions } = obj
   if (!tag) return text
   let child = ''

--- a/src/platforms/mp/compiler/codegen/index.js
+++ b/src/platforms/mp/compiler/codegen/index.js
@@ -25,6 +25,10 @@ export function compileToWxml (compiled, options = {}) {
     const slot = scopedSlots[k]
     slot.code = generate(slot.node, options)
   })
+
+  // mpvue-loader 只使用了 slots， 这儿将slots, scopedSlots 合并
+  Object.assign(slots, scopedSlots)
+
   // TODO: 后期优化掉这种暴力全部 import，虽然对性能没啥大影响
   return { code, compiled, slots, scopedSlots, importCode }
 }

--- a/src/platforms/mp/compiler/codegen/index.js
+++ b/src/platforms/mp/compiler/codegen/index.js
@@ -7,7 +7,7 @@ export function compileToWxml (compiled, options = {}) {
   const { components = {}} = options
   const log = utils.log(compiled)
 
-  const { wxast, deps = {}, slots = {}} = wxmlAst(compiled, options, log)
+  const { wxast, deps = {}, slots = {}, scopedSlots = {}} = wxmlAst(compiled, options, log)
   let code = generate(wxast, options)
 
   // 引用子模版
@@ -20,6 +20,11 @@ export function compileToWxml (compiled, options = {}) {
     slot.code = generate(slot.node, options)
   })
 
+  // 生成 scoped slot code
+  Object.keys(scopedSlots).forEach(function (k) {
+    const slot = scopedSlots[k]
+    slot.code = generate(slot.node, options)
+  })
   // TODO: 后期优化掉这种暴力全部 import，虽然对性能没啥大影响
-  return { code, compiled, slots, importCode }
+  return { code, compiled, slots, scopedSlots, importCode }
 }

--- a/src/platforms/mp/compiler/codegen/index.js
+++ b/src/platforms/mp/compiler/codegen/index.js
@@ -26,9 +26,6 @@ export function compileToWxml (compiled, options = {}) {
     slot.code = generate(slot.node, options)
   })
 
-  // mpvue-loader 只使用了 slots， 这儿将slots, scopedSlots 合并
-  Object.assign(slots, scopedSlots)
-
   // TODO: 后期优化掉这种暴力全部 import，虽然对性能没啥大影响
   return { code, compiled, slots, scopedSlots, importCode }
 }

--- a/src/platforms/mp/compiler/codegen/utils.scopeslot.js
+++ b/src/platforms/mp/compiler/codegen/utils.scopeslot.js
@@ -1,0 +1,105 @@
+/**
+ * 替换模板中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+export const replaceVarSimple = (alias, aliasFull) => str =>
+  str
+    .replace(new RegExp(`^${alias}$`), aliasFull)
+    .replace(new RegExp(`\\.${alias}\\.`, 'g'), `.${aliasFull}.`)
+    .replace(new RegExp(`'${alias}'`, 'g'), `'${aliasFull}'`)
+    .replace(new RegExp(`^${alias}\\.`), `${aliasFull}.`)
+    .replace(new RegExp(`\\.${alias}$`), `.${aliasFull}`)
+/**
+ * 替换 astMap 属性中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+const replaceSlotScopeVar = (alias, aliasFull) => str =>
+  str
+    .replace(new RegExp(`^${alias}$`), aliasFull)
+    .replace(new RegExp(`^${alias}\\.`), `${aliasFull}.`)
+/**
+ * 替换 astMap 静态模板部分中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+const replaceTemplateVar = (alias, aliasFull) => str => {
+  const result = str
+    .replace(new RegExp(`^\\(${alias}\\)`, 'g'), `(${aliasFull})`)
+    .replace(new RegExp(`^\\(${alias}\\.`, 'g'), `(${aliasFull}.`)
+  return result
+}
+/**
+ * 使用替换参数创建一个用于生成{expression, text}的方法，简化调用
+ * @param {string} target 模板变量名
+ * @param {string} using 约定变量名
+ * @returns { expression, text }
+ */
+const expressionReplacerFactory = (
+  target,
+  using = '$scopedata'
+) => expression => {
+  const arr = expression.split(/(\(.*?\))/g)
+  const textArr = arr.slice()
+  const replacer = replaceTemplateVar(target, using)
+  const result = arr
+    .map((str, idx) => {
+      if (!/^\(.*?\)$/.test(str)) return
+      const mainStr = replacer(str)
+      textArr[idx] = `(\`${mainStr.slice(1, mainStr.length - 1)}\`)`
+      return `${replacer(str)}`
+    })
+    .join('')
+  let text = ''
+  const _s = str => `{{ ${str} }}`
+  try {
+    text = eval(textArr.join('').replace(/\n/g, '\\n'))
+  } catch (e) {
+    console.info(_s(text), e)
+  }
+  return { expression: result, text }
+}
+
+/**
+ * 替换当前节点属性、静态模板中使用的作用域变量，如果有
+ * @param { astNode } nodeAst 节点词法树
+ */
+export const replaceVarStr = nodeAst => {
+  if (!nodeAst.replaceTarget) return nodeAst
+  const { replaceTarget } = nodeAst
+  const replacer = replaceSlotScopeVar(replaceTarget, '$scopedata')
+  const expressionReplacer = expressionReplacerFactory(
+    replaceTarget,
+    '$scopedata'
+  )
+  const cache = {}
+  let { attrs = [], attrsList = [] } = nodeAst
+  const { attrsMap = {}} = nodeAst
+  const getValueWithCache = oriValue => {
+    let value
+    if (cache[oriValue] !== undefined) {
+      value = cache[oriValue]
+    } else {
+      value = replacer(oriValue)
+      cache[oriValue] = value
+    }
+    return value
+  }
+  const mapFn = item => Object.assign({}, item, { value: getValueWithCache(item.value) })
+  attrs = attrs.map(mapFn)
+  attrsList = attrsList.map(mapFn)
+  const newMap = {}
+  Object.keys(attrsMap).forEach(key => {
+    if (!key.startsWith(':')) return
+    newMap[key] = getValueWithCache(attrsMap[key])
+  })
+  const newNode = Object.assign({}, nodeAst, { attrs, attrsList, attrsMap: newMap })
+  // 替换静态内容
+  if (newNode.expression) {
+    const { expression, text } = expressionReplacer(newNode.expression)
+    newNode.expression = expression
+    newNode.text = text || newNode.text
+  }
+  return newNode
+}

--- a/src/platforms/mp/compiler/codegen/utils.scopeslot.js
+++ b/src/platforms/mp/compiler/codegen/utils.scopeslot.js
@@ -103,3 +103,35 @@ export const replaceVarStr = (nodeAst, options = {}) => {
   }
   return newNode
 }
+/**
+ * 获取检查节点含有变量的绑定属性
+ * @param {*} attrsList 节点属性列表
+ */
+export function getBindings (attrsList) {
+  const bindingAttrs = []
+  const bingAttr = /^(:|v-bind(:?))/
+  attrsList.forEach(({ name, value }) => {
+    if (bingAttr.test(name)) {
+      const varName = name.replace(bingAttr, '')
+      bindingAttrs.push({ name: varName, value })
+    }
+  })
+  return bindingAttrs
+}
+
+/**
+ * 递归查找for数据
+ * @param {*} ast 节点
+ */
+export function getClosestFor (ast) {
+  let target
+  let currentAst = { parent: ast }
+  while (currentAst.parent) {
+    currentAst = currentAst.parent
+    if (currentAst.for) {
+      target = currentAst
+      break
+    }
+  }
+  return target
+}

--- a/src/platforms/mp/compiler/codegen/utils.scopeslot.js
+++ b/src/platforms/mp/compiler/codegen/utils.scopeslot.js
@@ -65,9 +65,9 @@ const expressionReplacerFactory = (
  * 替换当前节点属性、静态模板中使用的作用域变量，如果有
  * @param { astNode } nodeAst 节点词法树
  */
-export const replaceVarStr = nodeAst => {
-  if (!nodeAst.replaceTarget) return nodeAst
-  const { replaceTarget } = nodeAst
+export const replaceVarStr = (nodeAst, options = {}) => {
+  const { replaceTarget } = options
+  if (!replaceTarget) return nodeAst
   const replacer = replaceSlotScopeVar(replaceTarget, '$scopedata')
   const expressionReplacer = expressionReplacerFactory(
     replaceTarget,

--- a/src/platforms/mp/compiler/mark-component.js
+++ b/src/platforms/mp/compiler/mark-component.js
@@ -103,6 +103,9 @@ function mark (path, options, deps, iteratorArr = []) {
   // eg. '1-'+i+'-'+j
   const value = getWxEleId(deps.comIndex, currentArr)
   addAttr(path, 'mpcomid', value, true)
+  if (currentArr[0]) {
+    addAttr(path, 'mpcomidx', currentArr[0], true)
+  }
   path['mpcomid'] = value
   deps.comIndex += 1
 }

--- a/src/platforms/mp/compiler/mark-component.js
+++ b/src/platforms/mp/compiler/mark-component.js
@@ -50,7 +50,7 @@ function addAttr (path, key, value, inVdom) {
 function mark (path, options, deps, iteratorArr = []) {
   fixDefaultIterator(path)
 
-  const { tag, children, iterator1, events, directives, ifConditions } = path
+  const { tag, children, scopedSlots, iterator1, events, directives, ifConditions } = path
 
   const currentArr = Object.assign([], iteratorArr)
 
@@ -64,6 +64,12 @@ function mark (path, options, deps, iteratorArr = []) {
   if (children && children.length) {
     children.forEach((v, i) => {
       // const counterIterator = children.slice(0, i).filter(v => v.for).map(v => v.for + '.length').join(`+'-'+`)
+      mark(v, options, deps, currentArr)
+    })
+  }
+  // 递归 scopedSlot
+  if (scopedSlots) {
+    Object.values(scopedSlots).forEach(v => {
       mark(v, options, deps, currentArr)
     })
   }

--- a/src/platforms/mp/runtime/render.js
+++ b/src/platforms/mp/runtime/render.js
@@ -115,6 +115,9 @@ function throttle (func, wait, options) {
 
 // 优化频繁的 setData: https://mp.weixin.qq.com/debug/wxadoc/dev/framework/performance/tips.html
 const throttleSetData = throttle((handle, data) => {
+  Object.keys(data).forEach(key => {
+    if (data[key] === undefined) delete data[key]
+  })
   handle(data)
 }, 50)
 

--- a/test/mp/compiler/index.spec.js
+++ b/test/mp/compiler/index.spec.js
@@ -14,6 +14,7 @@ function assertCodegen (template, assertTemplate, options, parmas = {}) {
   // expect(output.code.replace(/\n/g, '')).toMatch(strToRegExp(assertTemplate))
 }
 
+
 describe('a', () => {
   it('tag a', () => {
     assertCodegen(
@@ -559,6 +560,52 @@ describe('slot', () => {
       `<template name="a"><view class="_div"><template name="default">test</template><template data="{{...$root[$k], $root}}" is="{{$for[tab.key]}}"></template></view></template>`,
       {
         name: 'a'
+      }
+    )
+  })
+
+  it('作用域插槽组件(运行时不会多渲染一层template)', () => {
+    assertCodegen(
+      `<template><div class="list"><div v-for="(item, i) in items" :key="i"><slot v-bind="item.withBind" v-bind:normal="item.withKey" v-bind:out="compData[i]"></slot></div></div></template>`,
+      `<import src="/components/slots" /><template name="44d7fa62"><template><template name="default"></template><view class="_div data-v-6ff79fe1 list"><view wx:key="i" key="{{i}}" wx:for="{{items}}" wx:for-index="i" wx:for-item="item" class="_div data-v-6ff79fe1"><template data="{{ ...$root[$p], ...$root[$k], $root, $scopedata: { ...$root[$k]['items'][i].withBind ,normal: $root[$k]['items'][i].withKey ,out: $root[$k].compData[i]  } }}" is="{{$slotdefault || 'default'}}"></template></view></view></template></template>`,
+      {
+        components: {
+          isCompleted: true,
+          slots: { src: '/components/slots', name: 'slots' }
+        },
+        pageType: 'component',
+        name: '44d7fa62',
+        moduleId: 'data-v-6ff79fe1'
+      }
+    )
+  })
+  // 未能生成slot.wxml
+  it('使用作用域插槽组件(运行时不会多渲染一层template)', () => {
+    assertCodegen(
+      `<template>
+      <div class="app">
+        <div class="scope">
+          <comp>
+            <div class="scop" slot-scope="subName">
+                <div class="co" :d='subName.normal'>
+                  . {{ subName.out }} . {{subName.viaBind}}. {{ subName.out.comp }}
+                </div>
+            </div>
+          </comp>
+        </div>
+      </div>
+    </template>`,
+      `<import src="/list/index.vue.wxml" /><template name="3f5387cc"><template><view class="_div data-v-2dea727a app"><view class="_div data-v-2dea727a scope"><template data="{{...$root[$kk+'0'], $root, $for:{default:'data-v-2dea727a-default-0'},$slotdefault:'data-v-2dea727a-default-0'}}" is="44d7fa62"></template></view></view></template></template>`,
+      {
+        components: {
+          comp: { src: '/list/index.vue.wxml', name: '44d7fa62' },
+          isCompleted: true,
+          slots: { src: '/components/slots', name: 'slots' }
+        },
+        pageType: 'component',
+        name: '3f5387cc',
+        moduleId: 'data-v-2dea727a',
+        fromScopedSlot: 'subName'
       }
     )
   })


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

实现关键点：
 slot-scope 生成到slot.wxml 中： scopedSlots目前一个 slot[name] 仅支持一个子组件。收集到时，将之与slots合并
 slot-scope 作用参数： 操作ast，后处理，将自定义别名全部替换成约定的 $scopedata。在 template[data] 中拼接 slotscope参数
 v-for 下使用slot-scope :模板，js文件中render函数进行同步改造。遇到 slot-scope后，使用形如 `$root[$kk + '0v1'], $root[$kk + '0v2']` 的变量