### PR TITLE
slot scope  支持

### DIFF
--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -32,6 +32,10 @@ export class CodegenState {
   }
 }
 
+export type WithLast = {
+  needSuffix: Boolean
+}
+
 export type CodegenResult = {
   render: string,
   staticRenderFns: Array<string>
@@ -49,7 +53,7 @@ export function generate (
   }
 }
 
-export function genElement (el: ASTElement, state: CodegenState): string {
+export function genElement (el: ASTElement, state: CodegenState, withLast: WithLast): string {
   if (el.staticRoot && !el.staticProcessed) {
     return genStatic(el, state)
   } else if (el.once && !el.onceProcessed) {
@@ -66,11 +70,10 @@ export function genElement (el: ASTElement, state: CodegenState): string {
     // component or element
     let code
     if (el.component) {
-      code = genComponent(el.component, el, state)
+      code = genComponent(el.component, el, state, withLast)
     } else {
-      const data = el.plain ? undefined : genData(el, state)
-
-      const children = el.inlineTemplate ? null : genChildren(el, state, true)
+      const data = el.plain ? undefined : genData(el, state, withLast)
+      const children = el.inlineTemplate ? null : genChildren(el, state, true, undefined, undefined, withLast)
       code = `_c('${el.tag}'${
         data ? `,${data}` : '' // data
       }${
@@ -192,7 +195,7 @@ export function genFor (
     '})'
 }
 
-export function genData (el: ASTElement, state: CodegenState): string {
+export function genData (el: ASTElement, state: CodegenState, withLast: WithLast): string {
   let data = '{'
 
   // directives first.
@@ -225,7 +228,7 @@ export function genData (el: ASTElement, state: CodegenState): string {
   }
   // attributes
   if (el.attrs) {
-    data += `attrs:{${genProps(el.attrs)}},`
+    data += `attrs:{${genProps(el.attrs, withLast)}},`
   }
   // DOM props
   if (el.props) {
@@ -258,7 +261,7 @@ export function genData (el: ASTElement, state: CodegenState): string {
   }
   // inline-template
   if (el.inlineTemplate) {
-    const inlineTemplate = genInlineTemplate(el, state)
+    const inlineTemplate = genInlineTemplate(el, state, withLast)
     if (inlineTemplate) {
       data += `${inlineTemplate},`
     }
@@ -306,7 +309,7 @@ function genDirectives (el: ASTElement, state: CodegenState): string | void {
   }
 }
 
-function genInlineTemplate (el: ASTElement, state: CodegenState): ?string {
+function genInlineTemplate (el: ASTElement, state: CodegenState, withLast: WithLast): ?string {
   const ast = el.children[0]
   if (process.env.NODE_ENV !== 'production' && (
     el.children.length > 1 || ast.type !== 1
@@ -314,7 +317,7 @@ function genInlineTemplate (el: ASTElement, state: CodegenState): ?string {
     state.warn('Inline-template components must have exactly one child element.')
   }
   if (ast.type === 1) {
-    const inlineRenderFns = generate(ast, state.options)
+    const inlineRenderFns = generate(ast, state.options, withLast)
     return `inlineTemplate:{render:function(){${
       inlineRenderFns.render
     }},staticRenderFns:[${
@@ -342,10 +345,11 @@ function genScopedSlot (
   if (el.for && !el.forProcessed) {
     return genForScopedSlot(key, el, state)
   }
-  return `{key:${key},fn:function(${String(el.attrsMap.scope)}){` +
+  return `{key:${key},fn:function(${String(el.slotScope)}){` +
+    `const _last = ${el.slotScope}.mpcomidx === undefined ? '' : 'v' + ${el.slotScope}.mpcomidx;\n` +
     `return ${el.tag === 'template'
       ? genChildren(el, state) || 'void 0'
-      : genElement(el, state)
+      : genElement(el, state, { needSuffix: true })
   }}}`
 }
 
@@ -370,7 +374,8 @@ export function genChildren (
   state: CodegenState,
   checkSkip?: boolean,
   altGenElement?: Function,
-  altGenNode?: Function
+  altGenNode?: Function,
+  withLast?: WithLast
 ): string | void {
   const children = el.children
   if (children.length) {
@@ -387,7 +392,7 @@ export function genChildren (
       ? getNormalizationType(children, state.maybeComponent)
       : 0
     const gen = altGenNode || genNode
-    return `[${children.map(c => gen(c, state)).join(',')}]${
+    return `[${children.map(c => gen(c, state, Object.assign({}, withLast))).join(',')}]${
       normalizationType ? `,${normalizationType}` : ''
     }`
   }
@@ -424,9 +429,9 @@ function needsNormalization (el: ASTElement): boolean {
   return el.for !== undefined || el.tag === 'template' || el.tag === 'slot'
 }
 
-function genNode (node: ASTNode, state: CodegenState): string {
+function genNode (node: ASTNode, state: CodegenState, withLast: WithLast): string {
   if (node.type === 1) {
-    return genElement(node, state)
+    return genElement(node, state, withLast)
   } if (node.type === 3 && node.isComment) {
     return genComment(node)
   } else {
@@ -467,19 +472,29 @@ function genSlot (el: ASTElement, state: CodegenState): string {
 function genComponent (
   componentName: string,
   el: ASTElement,
-  state: CodegenState
+  state: CodegenState,
+  withLast: WithLast
 ): string {
   const children = el.inlineTemplate ? null : genChildren(el, state, true)
-  return `_c(${componentName},${genData(el, state)}${
+  return `_c(${componentName},${genData(el, state, withLast)}${
     children ? `,${children}` : ''
   })`
 }
 
-function genProps (props: Array<{ name: string, value: string }>): string {
+function genProps (props: Array<{ name: string, value: string }>, withLast: WithLast): string {
   let res = ''
+  let consumed = false
   for (let i = 0; i < props.length; i++) {
     const prop = props[i]
-    res += `"${prop.name}":${transformSpecialNewlines(prop.value)},`
+    res += `"${prop.name}":${transformSpecialNewlines(prop.value)}`
+    if (withLast && withLast.needSuffix && prop.name === 'mpcomid') {
+      consumed = true
+      res += '+_last '
+    }
+    res += ','
+  }
+  if (consumed) {
+    withLast.needSuffix = false
   }
   return res.slice(0, -1)
 }

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -428,12 +428,14 @@ function processSlot (el) {
       )
     }
   } else {
+    // 添加slotScope属性，vue 2.5+
+    el.slotScope = getAndRemoveAttr(el, 'slot-scope')
     const slotTarget = getBindingAttr(el, 'slot')
     if (slotTarget) {
       el.slotTarget = slotTarget === '""' ? '"default"' : slotTarget
-    }
-    if (el.tag === 'template') {
-      el.slotScope = getAndRemoveAttr(el, 'scope')
+      if (el.tag !== 'template' && !el.slotScope) {
+        addAttr(el, 'slot', slotTarget)
+      }
     }
   }
 }

--- a/src/platforms/mp/compiler/codegen/convert/component.js
+++ b/src/platforms/mp/compiler/codegen/convert/component.js
@@ -1,3 +1,5 @@
+import { replaceVarSimple, getClosestFor, attrValStringify } from '../utils.scopeslot'
+
 function getSlotsName (obj) {
   if (!obj) {
     return ''
@@ -25,20 +27,88 @@ function tmplateSlotsObj(obj) {
   return $for ? [`$for:{${$for}}`] : []
 }
 
+/**
+ * 将组件绑定的属性拼接到 $scopedata 中向下传
+ * @param {*} attrsList 绑定的属性值
+ * @param {*} closestForNode 最近一层的for节点（如果有）
+ */
+function tagBindingAttrs (attrsList, closestForNode) {
+  let genKeyStr = v => v
+  if (closestForNode) {
+    // 有 v-for 场景，替换模板中约定的slot-scope。因slot只有一份，采用slot-scope统一成一个的处理方式
+    const { alias, for: forName, iterator1 } = closestForNode
+    const aliasFull = `${forName}[${iterator1}]`
+    genKeyStr = replaceVarSimple(alias, aliasFull)
+  }
+  const varRootStr = '$root[$k]'
+  const scopeAttrs = []
+  attrsList.forEach(({ name, value }) => {
+    let bindTarget = false
+    if (name.startsWith(':')) {
+      bindTarget = name.slice(1)
+    } else if (name.startsWith('v-bind')) {
+      bindTarget = name.slice('v-bind'.length + 1)
+    } else {
+      // 非动态绑定attr
+      scopeAttrs.push(`${name}: '${attrValStringify(value)}'`)
+    }
+    if (bindTarget === false) return
+    let bindValStr
+    if (typeof value !== 'string' || // 这几种条件直接取用，不替换。
+      /^[\d\.\-\+]+$/.test(value) || // 是数字，
+      ['true', 'false'].includes(value) || // 是布尔值
+      ['\'', '"', '{', '['].includes(value[0])) { // 是数组，字符串
+      // TODO 数组中存在变量，对象的动态key等可能迭代此方法进行替换
+      bindValStr = value
+    } else {
+      const pathStr = genKeyStr(value)
+      // 区分取变量方式：$root[$k].data 或 $root[$k][idx]
+      const varSep = pathStr[0] === '[' ? '' : '.'
+      bindValStr = pathStr.startsWith('$scopedata') ? pathStr : `${varRootStr}${varSep}${pathStr}`
+    }
+    if (bindTarget === '') {
+      // v-bind="data" 情况
+      scopeAttrs.push(`...${bindValStr}`)
+    } else {
+      // v-bind:something="varible" 情况
+      scopeAttrs.push(`${bindTarget}: ${bindValStr}`)
+    }
+  })
+  return scopeAttrs
+}
+
 export default {
   isComponent (tagName, components = {}) {
     return !!components[tagName]
   },
   convertComponent (ast, components, slotName) {
-    const { attrsMap, tag, mpcomid, slots } = ast
+    const { attrsMap, tag, mpcomid, slots, attrsList } = ast
+    // 查询最新的 v-for 模板slotScope变量
+    const closestForNode = getClosestFor(ast)
+    // 对于scope，手动添加一份标签上绑定的变量
+    const scopeAttrs = tagBindingAttrs(attrsList, closestForNode)
+    let scopeAttrStr = ''
+    let scopeIdStr = ''
+    if (scopeAttrs.length) {
+      scopeAttrStr = `,$scopedata:{${scopeAttrs.join()} }`
+      // 对于scope，添加一份索引
+      scopeIdStr = closestForNode && closestForNode.iterator1 ? `,$slotidx:'v'+${closestForNode.iterator1}` : ''
+    }
     if (slotName) {
-      attrsMap['data'] = "{{...$root[$p], ...$root[$k], $root}}"
-      // bindedName is available when rendering slot in v-for
+      // 有 slot-scoped 在原有的 <template data=‘... 上增加作用域数据，约定使用 '$scopedata' 为替换变量名
+      attrsMap['data'] = `{{...$root[$p], ...$root[$k], $root${scopeAttrStr}${scopeIdStr} }}`
+      // slotAst 的 'v-bind:name' 不会在attrsList中出现，以此判断当前slot绑定了动态 name
       const bindedName = attrsMap['v-bind:name']
-      if(bindedName) {
-        attrsMap['is'] = "{{$for[" + bindedName + "]}}"
+      if (bindedName) {
+        const alias = closestForNode && closestForNode.alias
+        // 如果 slot[:name] 在v-for作用域里
+        if (alias && bindedName.startsWith(alias) && ['.', '', undefined].includes(bindedName[alias.length])) {
+          attrsMap['is'] = `{{$for[${bindedName}] || 'default'}}`
+        } else {
+          attrsMap['is'] = `{{ $for[$root[$k].${bindedName}] || 'default' }}`
+        }
       } else {
-        attrsMap['is'] = "{{" + slotName + "}}"
+        attrsMap['is'] = `{{${slotName}}}`
       }
     } else {
       const slotsName = getSlotsName(slots)

--- a/src/platforms/mp/compiler/codegen/convert/component.js
+++ b/src/platforms/mp/compiler/codegen/convert/component.js
@@ -113,7 +113,7 @@ export default {
     } else {
       const slotsName = getSlotsName(slots)
       const restSlotsName = slotsName ? `, ${slotsName}` : ''
-      attrsMap['data'] = `{{...$root[$kk+${mpcomid}], $root${restSlotsName}}}`
+      attrsMap['data'] = `{{...$root[$kk+${mpcomid}+($slotidx || '')], $root${restSlotsName}${scopeAttrStr} }}`
       attrsMap['is'] = components[tag].name
     }
     return ast

--- a/src/platforms/mp/compiler/codegen/convert/component.js
+++ b/src/platforms/mp/compiler/codegen/convert/component.js
@@ -7,22 +7,17 @@ function getSlotsName (obj) {
   // wxml模板中 data="{{ a:{a1:'string2'}, b:'string'}}" 键a不能放在最后，会出错
   return tmplateSlotsObj(obj)
     .concat(
-      Object.keys(obj).map(function(k) {
-        return '$slot' + k + ":'" + obj[k] + "'"
-      })
-    )
+      Object.keys(obj).map(k => '$slot' + k + ":'" + obj[k] + "'"))
     .join(',')
 }
 
-function tmplateSlotsObj(obj) {
+function tmplateSlotsObj (obj) {
   if (!obj) {
     return []
   }
   // wxml模板中 data="{{ a:{a1:'string2'}, b:'string'}}" 键a1不能写成 'a1' 带引号的形式，会出错
   const $for = Object.keys(obj)
-    .map(function(k) {
-      return `${k}:'${obj[k]}'`
-    })
+    .map(k => `${k}:'${obj[k]}'`)
     .join(',')
   return $for ? [`$for:{${$for}}`] : []
 }
@@ -55,7 +50,7 @@ function tagBindingAttrs (attrsList, closestForNode) {
     if (bindTarget === false) return
     let bindValStr
     if (typeof value !== 'string' || // 这几种条件直接取用，不替换。
-      /^[\d\.\-\+]+$/.test(value) || // 是数字，
+      /^[+\-\d.]+$/.test(value) || // 是数字，
       ['true', 'false'].includes(value) || // 是布尔值
       ['\'', '"', '{', '['].includes(value[0])) { // 是数组，字符串
       // TODO 数组中存在变量，对象的动态key等可能迭代此方法进行替换

--- a/src/platforms/mp/compiler/codegen/convert/tag.js
+++ b/src/platforms/mp/compiler/codegen/convert/tag.js
@@ -3,7 +3,7 @@ import tagMap from '../config/wxmlTagMap'
 
 export default function (ast, options) {
   const { tag, elseif, else: elseText, for: forText, staticClass = '', attrsMap = {}} = ast
-  const { components } = options
+  const { components, fromSlotScope } = options
   const { 'v-if': ifText, href, 'v-bind:href': bindHref, name } = attrsMap
 
   if (!tag) {
@@ -15,11 +15,12 @@ export default function (ast, options) {
   }
   ast.tag = tagMap[tag] || tag
 
-  const isSlot = tag === 'slot'
+  const isSlot = tag === 'slot' || ast.slotScope
 
   if ((ifText || elseif || elseText || forText) && tag === 'template') {
     ast.tag = 'block'
-  } else if (isComponent || isSlot) {
+  } else if (isComponent || (isSlot && !fromSlotScope)) {
+    // scopedSlot 会迭代 普通slot的方法，不需要再用template替换，视为普通view
     const originSlotName = name || 'default'
     const slotName = isSlot ? `$slot${originSlotName} || '${originSlotName}'` : undefined
 

--- a/src/platforms/mp/compiler/codegen/generate.js
+++ b/src/platforms/mp/compiler/codegen/generate.js
@@ -1,4 +1,4 @@
-export default function generate (obj, options = {}) {
+export default function generate (obj = {}, options = {}) {
   const { tag, attrsMap = {}, children, text, ifConditions } = obj
   if (!tag) return text
   let child = ''

--- a/src/platforms/mp/compiler/codegen/index.js
+++ b/src/platforms/mp/compiler/codegen/index.js
@@ -7,7 +7,7 @@ export function compileToWxml (compiled, options = {}) {
   const { components = {}} = options
   const log = utils.log(compiled)
 
-  const { wxast, deps = {}, slots = {}} = wxmlAst(compiled, options, log)
+  const { wxast, deps = {}, slots = {}, scopedSlots = {}} = wxmlAst(compiled, options, log)
   let code = generate(wxast, options)
 
   // 引用子模版
@@ -20,6 +20,12 @@ export function compileToWxml (compiled, options = {}) {
     slot.code = generate(slot.node, options)
   })
 
+  // 生成 scoped slot code
+  Object.keys(scopedSlots).forEach(function (k) {
+    const slot = scopedSlots[k]
+    slot.code = generate(slot.node, options)
+  })
+
   // TODO: 后期优化掉这种暴力全部 import，虽然对性能没啥大影响
-  return { code, compiled, slots, importCode }
+  return { code, compiled, slots, scopedSlots, importCode }
 }

--- a/src/platforms/mp/compiler/codegen/utils.scopeslot.js
+++ b/src/platforms/mp/compiler/codegen/utils.scopeslot.js
@@ -69,7 +69,9 @@ const expressionReplacerFactory = (
     .join('')
   let text = ''
   const _s = str => `{{ ${str} }}`
+  // 使用 ast提供的 expression 生成text
   try {
+    /* eslint no-eval: 0 */
     text = eval(textArr.join('').replace(/\n/g, '\\n'))
   } catch (e) {
     console.info(_s(text), e)

--- a/src/platforms/mp/compiler/codegen/utils.scopeslot.js
+++ b/src/platforms/mp/compiler/codegen/utils.scopeslot.js
@@ -1,0 +1,153 @@
+/**
+ * 转移字符串，输出至模板
+ * @param {*} valStr 静态字符串
+ */
+export const attrValStringify = valStr => {
+  let i = 0
+  while (valStr[i]) {
+    if (valStr[i - 1] !== '\\' && (valStr[i] === '"' || valStr[i] === "'")) {
+      valStr = `${valStr.slice(0, i)}\\${valStr.slice(i)}`
+      i++
+    }
+    i++
+  }
+  return valStr
+}
+
+/**
+ * 替换模板中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+export const replaceVarSimple = (alias, aliasFull) => str =>
+  str
+    .replace(new RegExp(`^${alias}$`), aliasFull)
+    .replace(new RegExp(`\\.${alias}\\.`, 'g'), `.${aliasFull}.`)
+    .replace(new RegExp(`'${alias}'`, 'g'), `'${aliasFull}'`)
+    .replace(new RegExp(`^${alias}\\.`), `${aliasFull}.`)
+    .replace(new RegExp(`\\.${alias}$`), `.${aliasFull}`)
+/**
+ * 替换 astMap 属性中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+const replaceSlotScopeVar = (alias, aliasFull) => str =>
+  str
+    .replace(new RegExp(`^${alias}$`), aliasFull)
+    .replace(new RegExp(`^${alias}\\.`), `${aliasFull}.`)
+/**
+ * 替换 astMap 静态模板部分中的变量名为约定变量名
+ * @param {string} alias 模板变量名
+ * @param {string} aliasFull 约定变量名
+ */
+const replaceTemplateVar = (alias, aliasFull) => str => {
+  const result = str
+    .replace(new RegExp(`^\\(${alias}\\)`, 'g'), `(${aliasFull})`)
+    .replace(new RegExp(`^\\(${alias}\\.`, 'g'), `(${aliasFull}.`)
+  return result
+}
+/**
+ * 使用替换参数创建一个用于生成{expression, text}的方法，简化调用
+ * @param {string} target 模板变量名
+ * @param {string} using 约定变量名
+ * @returns { expression, text }
+ */
+const expressionReplacerFactory = (
+  target,
+  using = '$scopedata'
+) => expression => {
+  const arr = expression.split(/(\(.*?\))/g)
+  const textArr = arr.slice()
+  const replacer = replaceTemplateVar(target, using)
+  const result = arr
+    .map((str, idx) => {
+      if (!/^\(.*?\)$/.test(str)) return
+      const mainStr = replacer(str)
+      textArr[idx] = `(\`${mainStr.slice(1, mainStr.length - 1)}\`)`
+      return `${replacer(str)}`
+    })
+    .join('')
+  let text = ''
+  const _s = str => `{{ ${str} }}`
+  try {
+    text = eval(textArr.join('').replace(/\n/g, '\\n'))
+  } catch (e) {
+    console.info(_s(text), e)
+  }
+  return { expression: result, text }
+}
+
+/**
+ * 替换当前节点属性、静态模板中使用的作用域变量，如果有
+ * @param { astNode } nodeAst 节点词法树
+ */
+export const replaceVarStr = (nodeAst, options = {}) => {
+  const { replaceTarget } = options
+  if (!replaceTarget) return nodeAst
+  const replacer = replaceSlotScopeVar(replaceTarget, '$scopedata')
+  const expressionReplacer = expressionReplacerFactory(
+    replaceTarget,
+    '$scopedata'
+  )
+  const cache = {}
+  let { attrs = [], attrsList = [] } = nodeAst
+  const { attrsMap = {}} = nodeAst
+  const getValueWithCache = oriValue => {
+    let value
+    if (cache[oriValue] !== undefined) {
+      value = cache[oriValue]
+    } else {
+      value = replacer(oriValue)
+      cache[oriValue] = value
+    }
+    return value
+  }
+  const mapFn = item => Object.assign({}, item, { value: getValueWithCache(item.value) })
+  attrs = attrs.map(mapFn)
+  attrsList = attrsList.map(mapFn)
+  const newMap = {}
+  Object.keys(attrsMap).forEach(key => {
+    if (!key.startsWith(':')) return
+    newMap[key] = getValueWithCache(attrsMap[key])
+  })
+  const newNode = Object.assign({}, nodeAst, { attrs, attrsList, attrsMap: newMap })
+  // 替换静态内容
+  if (newNode.expression) {
+    const { expression, text } = expressionReplacer(newNode.expression)
+    newNode.expression = expression
+    newNode.text = text || newNode.text
+  }
+  return newNode
+}
+/**
+ * 获取检查节点含有变量的绑定属性
+ * @param {*} attrsList 节点属性列表
+ */
+export function getBindings (attrsList) {
+  const bindingAttrs = []
+  const bingAttr = /^(:|v-bind(:?))/
+  attrsList.forEach(({ name, value }) => {
+    if (bingAttr.test(name)) {
+      const varName = name.replace(bingAttr, '')
+      bindingAttrs.push({ name: varName, value })
+    }
+  })
+  return bindingAttrs
+}
+
+/**
+ * 递归查找for数据
+ * @param {*} ast 节点
+ */
+export function getClosestFor (ast) {
+  let target
+  let currentAst = { parent: ast }
+  while (currentAst.parent) {
+    currentAst = currentAst.parent
+    if (currentAst.for) {
+      target = currentAst
+      break
+    }
+  }
+  return target
+}

--- a/src/platforms/mp/compiler/mark-component.js
+++ b/src/platforms/mp/compiler/mark-component.js
@@ -50,7 +50,7 @@ function addAttr (path, key, value, inVdom) {
 function mark (path, options, deps, iteratorArr = []) {
   fixDefaultIterator(path)
 
-  const { tag, children, iterator1, events, directives, ifConditions } = path
+  const { tag, children, scopedSlots, iterator1, events, directives, ifConditions } = path
 
   const currentArr = Object.assign([], iteratorArr)
 
@@ -64,6 +64,12 @@ function mark (path, options, deps, iteratorArr = []) {
   if (children && children.length) {
     children.forEach((v, i) => {
       // const counterIterator = children.slice(0, i).filter(v => v.for).map(v => v.for + '.length').join(`+'-'+`)
+      mark(v, options, deps, currentArr)
+    })
+  }
+  // 递归 scopedSlot
+  if (scopedSlots) {
+    Object.values(scopedSlots).forEach(v => {
       mark(v, options, deps, currentArr)
     })
   }
@@ -97,6 +103,9 @@ function mark (path, options, deps, iteratorArr = []) {
   // eg. '1-'+i+'-'+j
   const value = getWxEleId(deps.comIndex, currentArr)
   addAttr(path, 'mpcomid', value, true)
+  if (currentArr[0]) {
+    addAttr(path, 'mpcomidx', currentArr[0], true)
+  }
   path['mpcomid'] = value
   deps.comIndex += 1
 }

--- a/src/platforms/mp/runtime/events.js
+++ b/src/platforms/mp/runtime/events.js
@@ -60,7 +60,7 @@ function getHandle (vnode, eventid, eventTypes = []) {
 }
 
 function getWebEventByMP (e) {
-  const { type, timeStamp, touches, detail = {}, target = {}, currentTarget = {} } = e
+  const { type, timeStamp, touches, detail = {}, target = {}, currentTarget = {}} = e
   const { x, y } = detail
   const event = {
     mp: e,
@@ -84,7 +84,7 @@ function getWebEventByMP (e) {
 export function handleProxyWithVue (e) {
   const rootVueVM = this.$root
   const { type, target = {}, currentTarget } = e
-  const { dataset = {} } = currentTarget || target
+  const { dataset = {}} = currentTarget || target
   const { comkey = '', eventid } = dataset
   const vm = getVM(rootVueVM, comkey.split(','))
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
支持 slot-scope，变量取用方式与vue slot-scope一致，即标签定义变量别名

**Other information:**
- slot-scope 支持方式为vue 2.5+支持，屏蔽了以前版本的 template[slot] 方式
- slot上属性支持字面变量，数字，布尔值，不支持方法、表达式，数组，对象
在data向作用域下传时：
- wxml 上增加了 $scopedata $slot $for 三个约定变量，加长了 wxml 长度，转换后体积变大
可以通过牺牲 slot-scope 的标签变量的直接使用为代价，去掉$scopedata，有机会的话可讨论
- v-for下slot，生成的render函数中，为mpcomid添加了_last 索引后缀，使生成的vue示例使用的数据存储在形如 $root.0,1v1. 的 data 中，目前没看到副作用